### PR TITLE
Added support for plugins

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -20,6 +20,7 @@ var block = {
   list: /^( *)([*+-]|\d+\.) [^\0]+?(?:\n{2,}(?! )|\s*$)(?!\1bullet)\n*/,
   html: /^ *(?:comment|closed|closing) *(?:\n{2,}|\s*$)/,
   def: /^ *\[([^\]]+)\]: *([^\s]+)(?: +["(]([^\n]+)[")])? *(?:\n+|$)/,
+  plugin: /^ *\[([^\:\]]+):([^\]]+)\] *\n*/,
   paragraph: /^([^\n]+\n?(?!body))+\n*/,
   text: /^[^\n]+/
 };
@@ -271,6 +272,17 @@ block.token = function(src, tokens, top) {
         type: 'html',
         pre: cap[1] === 'pre',
         text: cap[0]
+      });
+      continue;
+    }
+
+    // plugin
+    if (cap = block.plugin.exec(src)) {
+      src = src.substring(cap[0].length);
+      tokens.push({
+        type: 'plugin',
+        plugin: cap[1],
+        arg: cap[2]
       });
       continue;
     }
@@ -627,6 +639,14 @@ var tok = function() {
       return '<p>'
         + parseText()
         + '</p>\n';
+    }
+    case 'plugin': {
+      try {
+        return marked.plugins[token.plugin](token.arg)
+          + '\n';
+      } catch(e) {
+        return '<p><strong>Plugin error: ' + token.plugin + '</strong></p>\n';
+      }
     }
   }
 };

--- a/test/index.js
+++ b/test/index.js
@@ -5,6 +5,12 @@ var fs = require('fs')
   , marked = require('marked')
   , dir = __dirname + '/tests';
 
+marked.plugins = {
+  youtube: function(arg) {
+    return '<iframe class="youtube" src="https://www.youtube.com/embed/' + arg + '"></iframe>';
+  }
+};
+
 var BREAK_ON_ERROR = false;
 
 var files;

--- a/test/tests/youtube.html
+++ b/test/tests/youtube.html
@@ -1,0 +1,4 @@
+<h1>A Youtube embed</h1>
+<p>This is a Youtube embed</p>
+<iframe class="youtube" src="https://www.youtube.com/embed/g2FOLrC2e6E"></iframe>
+

--- a/test/tests/youtube.text
+++ b/test/tests/youtube.text
@@ -1,0 +1,5 @@
+# A Youtube embed
+This is a Youtube embed
+
+[youtube:g2FOLrC2e6E]
+


### PR DESCRIPTION
This adds support for plugins using the `[plugin_name:arg]` syntax.

`test/index.js` shows a basic "youtube" plugin.
