### PR TITLE
Markdown inside block tag

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -272,6 +272,7 @@ block.token = function(src, tokens, top) {
           tokens.push({
               type: 'html', pre: cap[1]==='pre', text: "</"+cap[1]+">"
           });
+          continue;
       }
     }
 

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -19,6 +19,7 @@ var block = {
   blockquote: /^( *>[^\n]+(\n[^\n]+)*\n*)+/,
   list: /^( *)(bull) [^\0]+?(?:hr|\n{2,}(?! )(?!\1bull )\n*|\s*$)/,
   html: /^ *(?:comment|closed|closing) *(?:\n{2,}|\s*$)/,
+  html_closed: /^ *(?:closed) *(?:\n{2,}|\s*$)/,
   def: /^ *\[([^\]]+)\]: *([^\s]+)(?: +["(]([^\n]+)[")])? *(?:\n+|$)/,
   paragraph: /^([^\n]+\n?(?!body))+\n*/,
   text: /^[^\n]+/
@@ -41,6 +42,11 @@ block.html = replace(block.html)
   ('closing', /<tag(?:"[^"]*"|'[^']*'|[^'">])*?>/)
   (/tag/g, tag())
   ();
+    
+block.html_closed = replace(block.html_closed)
+  ('closed', /<(tag)([^\0]+?)<\/\1>/)
+  (/tag/g, tag())
+  ();    
 
 block.paragraph = (function() {
   var paragraph = block.paragraph.source
@@ -251,6 +257,22 @@ block.token = function(src, tokens, top) {
       });
 
       continue;
+    }
+      
+    // html_closed
+    if (cap = block.html_closed.exec(src)) {
+      var atts = cap[2].substring(0,cap[2].indexOf(">"));
+      if (/markdown\s*=\s*('|"){0,1}1('|"){0,1}/.test(atts)) {
+          var inner = cap[2].substring(atts.length+1);
+          src = src.substring(cap[0].length);
+          tokens.push({
+            type: 'html', pre: cap[1]==='pre', text: "<"+cap[1]+atts+">"
+          });
+          block.token(inner,tokens,false);
+          tokens.push({
+              type: 'html', pre: cap[1]==='pre', text: "</"+cap[1]+">"
+          });
+      }
     }
 
     // html


### PR DESCRIPTION
Added support for syntax, where markdown is processed inside block html tag if markdown attribute is set to 1.
For example

``` html
<div markdown="1">
## Markdown header
</div>
```
