### PR TITLE
Added check for token.escaped in paragraph tok()

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -607,7 +607,7 @@ function tok() {
     }
     case 'paragraph': {
       return '<p>'
-        + inline.lexer(token.text)
+        + (token.escaped ? token.text : inline.lexer(token.text))
         + '</p>\n';
     }
     case 'text': {


### PR DESCRIPTION
Following #83, this does the same for paragraphs.
