### PR TITLE
Added option to preserve list numbering from input

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ marked has a few different switches which change behavior.
 - __smartLists__: Use smarter list behavior than the original markdown.
   Disabled by default. May eventually be default with the old behavior
   moved into `pedantic`.
+- __preserveNumbering__: Preserves the ordered list numbering of the input (allows starting at a number other than 1, counting down, skipping numbers, etc).
 - __langPrefix__: Set the prefix for code block classes. Defaults to `lang-`.
 
 ## Usage
@@ -88,6 +89,7 @@ marked.setOptions({
   pedantic: false,
   sanitize: true,
   smartLists: true,
+  preserveNumbering: false,
   langPrefix: 'language-',
   highlight: function(code, lang) {
     if (lang === 'js') {

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -327,7 +327,10 @@ Lexer.prototype.token = function(src, top) {
         this.tokens.push({
           type: loose
             ? 'loose_item_start'
-            : 'list_item_start'
+            : 'list_item_start',
+          value: this.options.preserveNumbering
+            ? /^ *(\d+\.)?/.exec(cap[i])[1]
+            : null
         });
 
         // Recurse.
@@ -917,7 +920,9 @@ Parser.prototype.tok = function() {
         + '>\n';
     }
     case 'list_item_start': {
-      var body = '';
+      var body = '', val_attr = '';
+      if (this.options.preserveNumbering && this.token.value)
+        val_attr = ' value="' + this.token.value.replace('.', '') + '"';
 
       while (this.next().type !== 'list_item_end') {
         body += this.token.type === 'text'
@@ -925,18 +930,20 @@ Parser.prototype.tok = function() {
           : this.tok();
       }
 
-      return '<li>'
+      return '<li' + val_attr + '>'
         + body
         + '</li>\n';
     }
     case 'loose_item_start': {
-      var body = '';
+      var body = '', val_attr = '';
+      if (this.options.preserveNumbering && this.token.value)
+        val_attr = ' value="' + this.token.value.replace('.', '') + '"';
 
       while (this.next().type !== 'list_item_end') {
         body += this.tok();
       }
 
-      return '<li>'
+      return '<li' + val_attr + '>'
         + body
         + '</li>\n';
     }
@@ -1041,6 +1048,7 @@ marked.defaults = {
   smartLists: false,
   silent: false,
   highlight: null,
+  preserveNumbering: false,
   langPrefix: 'lang-'
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -91,7 +91,8 @@ main:
         || (~filename.indexOf('.breaks.') && !marked.defaults.breaks)
         || (~filename.indexOf('.pedantic.') && !marked.defaults.pedantic)
         || (~filename.indexOf('.sanitize.') && !marked.defaults.sanitize)
-        || (~filename.indexOf('.smartlists.') && !marked.defaults.smartLists)) {
+        || (~filename.indexOf('.smartlists.') && !marked.defaults.smartLists)
+        || (~filename.indexOf('preserveNumbering.') && !marked.defaults.preserveNumbering)) {
       skipped++;
       console.log('#%d. %s skipped.', i + 1, filename);
       continue main;

--- a/test/new/preserveNumbering.html
+++ b/test/new/preserveNumbering.html
@@ -1,0 +1,23 @@
+<p>Reverse Ordered:</p>
+
+<ol>
+<li value="10">Tenth</li>
+<li value="9">Ninth</li>
+<li value="8">Eighth</li>
+</ol>
+
+<p>Every-Other Order:</p>
+
+<ol>
+<li value="1">First</li>
+<li value="3">Third</li>
+<li value="5">Fifth</li>
+</ol>
+
+<p>Random Two-Digit Order:</p>
+
+<ol>
+<li value="11">Eleventh</li>
+<li value="95">Ninety-fifth</li>
+<li value="03">Third</li>
+</ol>

--- a/test/new/preserveNumbering.text
+++ b/test/new/preserveNumbering.text
@@ -1,0 +1,17 @@
+Reverse Ordered:
+
+10. Tenth
+9. Ninth
+8. Eighth
+
+Every-Other Order:
+
+1. First
+3. Third
+5. Fifth
+
+Random Two-Digit Order:
+
+11. Eleventh
+95. Ninety-fifth
+03. Third

--- a/test/tests/preserveNumbering.html
+++ b/test/tests/preserveNumbering.html
@@ -1,0 +1,23 @@
+<p>Reverse Ordered:</p>
+
+<ol>
+<li value="10">Tenth</li>
+<li value="9">Ninth</li>
+<li value="8">Eighth</li>
+</ol>
+
+<p>Every-Other Order:</p>
+
+<ol>
+<li value="1">First</li>
+<li value="3">Third</li>
+<li value="5">Fifth</li>
+</ol>
+
+<p>Random Two-Digit Order:</p>
+
+<ol>
+<li value="11">Eleventh</li>
+<li value="95">Ninety-fifth</li>
+<li value="03">Third</li>
+</ol>

--- a/test/tests/preserveNumbering.text
+++ b/test/tests/preserveNumbering.text
@@ -1,0 +1,17 @@
+Reverse Ordered:
+
+10. Tenth
+9. Ninth
+8. Eighth
+
+Every-Other Order:
+
+1. First
+3. Third
+5. Fifth
+
+Random Two-Digit Order:
+
+11. Eleventh
+95. Ninety-fifth
+03. Third


### PR DESCRIPTION
@chjj: I'm not sure if you're interested in merging this feature, but I figured I would issue a pull request just in case.

Our use-case: Our app has large blocks of technical content in the form of ordered lists and there is occasionally block-level content in the list items (tables, multiple paragraphs, etc). The block-level content breaks up the list, so when a list is resumed, the actual numbering from the input should be used instead of starting over at "1".

I realize that the more semantically correct thing in this case would be to output a single list with the block-level content nested in it -- and this is possible with some markdown implementations (RedCarpet) but it places additional burden on the user to indent the block-level content beyond the indent of the list item it belongs in. Instead of going that route, this simple workaround gives the user more control and meets the user's expectations (I'm sure the end-users of our app would be surprised by markdown's default behavior -- as I was -- of ignoring the numbering from the input).

I added tests for the option, which pass when it the option is enabled (but a couple of pre-existing OL tests fail when the option is enabled because they aren't expecting the `value` attribute in the output `<li>`s). When the option is disabled (the default), the only pre-existing tests that fail are the 4 that normally fail (10-14). I added a `preserveNumbering` condition to tests\index.js so the new tests are skipped if the option is disabled. When disabled, the new option has a negligible effect on benchmark performance. When enabled, it adds, on average, about 50-70 milliseconds to the test time on my machine (~2%).
