### PR TITLE
Add code block pre class: `options.codeClass`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,14 @@ Default: `lang-`
 
 Set the prefix for code block classes.
 
+### codeClass
+
+Type: `String`
+Default: `null`
+
+Set the name for pre block classes. No class name be default.
+If set `codeClass: "prettyprint"`, will get `<pre class="prettyprint">`.
+
 ## Access to lexer and parser
 
 You also have direct access to the lexer and parser if you so desire.

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -866,7 +866,12 @@ Parser.prototype.tok = function() {
         this.token.text = escape(this.token.text, true);
       }
 
-      return '<pre><code'
+      var classname = '';
+      if (this.options.codeClass) {
+        classname = ' class="' + this.options.codeClass + '"';
+      }
+
+      return '<pre' + classname + '><code'
         + (this.token.lang
         ? ' class="'
         + this.options.langPrefix
@@ -1134,7 +1139,8 @@ marked.defaults = {
   silent: false,
   highlight: null,
   langPrefix: 'lang-',
-  smartypants: false
+  smartypants: false,
+  codeClass: null
 };
 
 /**


### PR DESCRIPTION
If we want to use [google-code-prettify](http://google-code-prettify.googlecode.com/svn/trunk/README.html) easily, we need to custom code block pre classname.

Set `options.codeClass="prettyprint"` and get `<pre class="prettyprint">` html result is pretty good.

@chjj
