### PR TITLE
Support for Inline and Display Math

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -204,7 +204,6 @@ Lexer.prototype.token = function(src, top, bq) {
 
     // math
     if (cap = this.rules.math.exec(src)) {
-      console.log(cap); //DEBUG
       src = src.substring(cap[0].length);
       this.tokens.push({
         type: 'math',
@@ -715,7 +714,6 @@ InlineLexer.prototype.output = function(src) {
 
     // math
     if (cap = this.rules.math.exec(src)) {
-      console.log(cap); //DEBUG
       src = src.substring(cap[0].length);
       out += '<script type="math/tex">'
         + cap[1] //FIXME: filter <script> & </script>

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -24,8 +24,9 @@ var block = {
   def: /^ *\[([^\]]+)\]: *<?([^\s>]+)>?(?: +["(]([^\n]+)[")])? *(?:\n+|$)/,
   task: noop,
   table: noop,
-  paragraph: /^((?:[^\n]+\n?(?!hr|heading|lheading|blockquote|tag|def))+)\n*/,
-  text: /^[^\n]+/
+  paragraph: /^((?:[^\n]+\n?(?!hr|heading|lheading|blockquote|tag|def|math))+)\n*/,
+  text: /^[^\n]+/,
+  math: /^ *(\${3,}) *([\s\S]+?)\s*\1 *(?:\n+|$)/
 };
 
 block.bullet = /(?:[*+-]|\d+\.)/;
@@ -63,6 +64,7 @@ block.paragraph = replace(block.paragraph)
   ('blockquote', block.blockquote)
   ('tag', '<' + block._tag)
   ('def', block.def)
+  ('math', block.math)
   ();
 
 /**
@@ -96,6 +98,7 @@ block.tables = merge({}, block.gfm, {
   table: /^ *\|(.+)\n *\|( *[-:]+[-| :]*)\n((?: *\|.*(?:\n|$))*)\n*/
 });
 
+
 /**
  * Block Lexer
  */
@@ -113,6 +116,10 @@ function Lexer(options) {
       this.rules = block.gfm;
     }
   }
+
+  /*if (!this.options.mathjax) {
+    this.rules.math = noop;
+  }*/
 }
 
 /**
@@ -191,6 +198,17 @@ Lexer.prototype.token = function(src, top, bq) {
         type: 'code',
         lang: cap[2],
         text: cap[3]
+      });
+      continue;
+    }
+
+    // math
+    if (cap = this.rules.math.exec(src)) {
+      console.log(cap); //DEBUG
+      src = src.substring(cap[0].length);
+      this.tokens.push({
+        type: 'math',
+        text: cap[2]
       });
       continue;
     }
@@ -475,7 +493,7 @@ Lexer.prototype.token = function(src, top, bq) {
  */
 
 var inline = {
-  escape: /^\\([\\`*{}\[\]()#+\-.!_>])/,
+  escape: /^\\([\\`*{}\[\]()#$+\-.!_>])/,
   autolink: /^<([^ >]+(@|:\/)[^ >]+)>/,
   url: noop,
   tag: /^<!--[\s\S]*?-->|^<\/?\w+(?:"[^"]*"|'[^']*'|[^'">])*?>/,
@@ -487,7 +505,8 @@ var inline = {
   code: /^(`+)\s*([\s\S]*?[^`])\s*\1(?!`)/,
   br: /^ {2,}\n(?!\s*$)/,
   del: noop,
-  text: /^[\s\S]+?(?=[\\<!\[_*`]| {2,}\n|$)/
+  text: /^[\s\S]+?(?=[\\<!\[_*`$]| {2,}\n|$)/,
+  math: /^\$\$\s*([\s\S]*?[^\$])\s*\$\$(?!\$)/ //FIXME: what if inline math contains `$`?
 };
 
 inline._inside = /(?:\[[^\]]*\]|[^\[\]]|\](?=[^\[]*\]))*/;
@@ -565,6 +584,10 @@ function InlineLexer(links, options) {
   } else if (this.options.pedantic) {
     this.rules = inline.pedantic;
   }
+
+  /*if (!this.options.mathjax) {
+    this.rules.math = noop;
+  }*/
 }
 
 /**
@@ -687,6 +710,16 @@ InlineLexer.prototype.output = function(src) {
     if (cap = this.rules.code.exec(src)) {
       src = src.substring(cap[0].length);
       out += this.renderer.codespan(escape(cap[2], true));
+      continue;
+    }
+
+    // math
+    if (cap = this.rules.math.exec(src)) {
+      console.log(cap); //DEBUG
+      src = src.substring(cap[0].length);
+      out += '<script type="math/tex">'
+        + cap[1] //FIXME: filter <script> & </script>
+        + '</script>';
       continue;
     }
 
@@ -1037,6 +1070,11 @@ Parser.prototype.tok = function() {
       }
 
       return this.renderer.tasklist(body);
+    }
+    case 'math': {
+      return '<script type="math/tex; mode=display">'
+        + this.token.text
+        + '</script>';
     }
     case 'table': {
       var header = ''

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -715,9 +715,7 @@ InlineLexer.prototype.output = function(src) {
     // math
     if (cap = this.rules.math.exec(src)) {
       src = src.substring(cap[0].length);
-      out += '<script type="math/tex">'
-        + cap[1] //FIXME: filter <script> & </script>
-        + '</script>';
+      out += this.renderer.math(cap[1], 'math/tex', false); //FIXME: filter <script> & </script>
       continue;
     }
 
@@ -913,6 +911,11 @@ Renderer.prototype.tablecell = function(content, flags) {
   return tag + content + '</' + type + '>\n';
 };
 
+Renderer.prototype.math = function(content, language, display) {
+  mode = display ? '; mode=display' : '';
+  return '<script type="' + language + mode + '">' + content + '</script>';
+}
+
 // span level renderer
 Renderer.prototype.strong = function(text) {
   return '<strong>' + text + '</strong>';
@@ -1070,9 +1073,7 @@ Parser.prototype.tok = function() {
       return this.renderer.tasklist(body);
     }
     case 'math': {
-      return '<script type="math/tex; mode=display">'
-        + this.token.text
-        + '</script>';
+      return this.renderer.math(this.token.text, 'math/tex', true);
     }
     case 'table': {
       var header = ''

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -26,7 +26,7 @@ var block = {
   table: noop,
   paragraph: /^((?:[^\n]+\n?(?!hr|heading|lheading|blockquote|tag|def|math))+)\n*/,
   text: /^[^\n]+/,
-  math: /^ *(\${3,}) *([\s\S]+?)\s*\1 *(?:\n+|$)/
+  math: /^ *(\${2,}) *([\s\S]+?)\s*\1 *(?:\n+|$)/
 };
 
 block.bullet = /(?:[*+-]|\d+\.)/;
@@ -117,9 +117,9 @@ function Lexer(options) {
     }
   }
 
-  /*if (!this.options.mathjax) {
+  if (!this.options.mathjax) {
     this.rules.math = noop;
-  }*/
+  }
 }
 
 /**
@@ -505,7 +505,7 @@ var inline = {
   br: /^ {2,}\n(?!\s*$)/,
   del: noop,
   text: /^[\s\S]+?(?=[\\<!\[_*`$]| {2,}\n|$)/,
-  math: /^\$\$\s*([\s\S]*?[^\$])\s*\$\$(?!\$)/ //FIXME: what if inline math contains `$`?
+  math: /^\$\s*([\s\S]*?[^\$])\s*\$(?!\$)/
 };
 
 inline._inside = /(?:\[[^\]]*\]|[^\[\]]|\](?=[^\[]*\]))*/;
@@ -584,9 +584,9 @@ function InlineLexer(links, options) {
     this.rules = inline.pedantic;
   }
 
-  /*if (!this.options.mathjax) {
+  if (!this.options.mathjax) {
     this.rules.math = noop;
-  }*/
+  }
 }
 
 /**
@@ -1327,7 +1327,8 @@ marked.defaults = {
   smartypants: false,
   headerPrefix: '',
   renderer: new Renderer,
-  xhtml: false
+  xhtml: false,
+  mathjax: true
 };
 
 /**

--- a/test/tests/math.html
+++ b/test/tests/math.html
@@ -1,0 +1,7 @@
+<p>$ this $ is <em>not</em> math $
+this <script type="math/tex">y=x^2</script> is math</p>
+<ul>
+<li>some list<br>some text  <script type="math/tex; mode=display">
+    y = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}</script></li>
+<li>some more list</li>
+</ul>

--- a/test/tests/math.text
+++ b/test/tests/math.text
@@ -1,0 +1,8 @@
+\$ this \$ is *not* math \$
+this $ y=x^2 $ is math
+*   some list  
+    some text  
+    $$
+        y = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}
+    $$
+*   some more list


### PR DESCRIPTION
I'm working to support [MathJax](http://www.mathjax.org/).

Output tag format:
http://docs.mathjax.org/en/latest/model.html#how-mathematics-is-stored-in-the-page

The idea for now:
- `$ ... $` => inline math
- `$$ ... $$` => display math

The code I wrote is mostly monkey-patching. Could anyone help get it settled?
