### PR TITLE
Add listeners on any token

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1070,6 +1070,16 @@ function marked(src, opt, callback) {
 
     for (; i < tokens.length; i++) {
       (function(token) {
+        if (opt.on && typeof opt.on[token.type] === 'function') {
+          return opt.on[token.type](token, function (err, text) {
+            if (text == null || text === token.text) {
+              return --pending || done();
+            }
+            token.text = text;
+            // escaped should be handled by the callback
+            --pending || done();
+          });
+        }
         if (token.type !== 'code') {
           return --pending || done();
         }


### PR DESCRIPTION
Instead of providing only a callback for code highlight, open the possibility to call a custom function for any token type.

This can be done with the configuration option `on`.

For instance

```
on : {
   heading : function () {}
}
```

I'm using this to generate anchors next to headings and the table of contents automatically.

``` js
var toc = [];
marked(input, {
    on: {
        heading : function (token, callback) {
            if (token.depth <= 3) {
                toc.push({
                    depth: token.depth,
                    title: token.text
                });
                callback(null, "<a name='" + token.text.toLowerCase().replace(/[ ]+/g, "_") + "'></a>" + token.text);
            } else {
                callback(null, token.text);
            }
        }
    }
}, function (err, content) {
    // do something with my content and TOC
});
```
