### PR TITLE
lex should only remove a tab in line start

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -130,7 +130,7 @@ Lexer.lex = function(src, options) {
 Lexer.prototype.lex = function(src) {
   src = src
     .replace(/\r\n|\r/g, '\n')
-    .replace(/\t/g, '    ')
+    .replace(/^\t/mg, '    ')
     .replace(/\u00a0/g, ' ')
     .replace(/\u2424/g, '\n');
 


### PR DESCRIPTION
lexer should only replace tabs to spaces if they are on the beginning of a line, otherwise those tabs may be meaningful (for example they can be part of a pre-formatted code string)
