### PR TITLE
add emoji parsing support to gfm markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,34 @@ Default: `false`
 
 Use "smart" typograhic punctuation for things like quotes and dashes.
 
+### emoji
+
+Type: `Boolean` / `String` / `Function`
+Default: `false`
+
+Enable replacement of colon-delimited Emoji emoticon codes like `:warning:` or `:+1:`. This option requires the `gfm` option to be true. :octocat: 
+
+* `String`: parsed as template for the replacement value, accepts the `{emoji}` variable.
+* `true`: use the default &lt;img&gt; with a local URL prefix.
+* `Function`: called with each emoji code, must return a replacement string like an &lt;img&gt; or &lt;span&gt; tag. Don't forget to use `escape(emoji)` or `encodeURIComponent(emoji)` where needed. 
+
+```js
+marked.setOptions({
+  emoji: function (emoji) {
+    return '<span data-emoji="' + emoji + '"></span>';
+  }
+});
+```
+
+The default template:
+
+````
+<img src="/graphics/emojis/warning.png" alt=":warning:" title=":warning:" 
+  class="emoji" align="absmiddle" height="20" width="20">`
+````
+
+:warning: The images for the emoji set used by GitHub can be found [in the repos](https://github.com/arvida/emoji-cheat-sheet.com/tree/master/public/graphics/emojis) of the [emoji-cheat-sheet](http://www.emoji-cheat-sheet.com/). :point_left::+1:
+
 ## Access to lexer and parser
 
 You also have direct access to the lexer and parser if you so desire.

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -453,6 +453,7 @@ var inline = {
   code: /^(`+)\s*([\s\S]*?[^`])\s*\1(?!`)/,
   br: /^ {2,}\n(?!\s*$)/,
   del: noop,
+  emoji: noop,
   text: /^[\s\S]+?(?=[\\<!\[_*`]| {2,}\n|$)/
 };
 
@@ -491,8 +492,9 @@ inline.gfm = merge({}, inline.normal, {
   escape: replace(inline.escape)('])', '~|])')(),
   url: /^(https?:\/\/[^\s<]+[^<.,:;"')\]\s])/,
   del: /^~~(?=\S)([\s\S]*?\S)~~/,
+  emoji: /^:([A-Za-z0-9_\-\+]+?):/,
   text: replace(inline.text)
-    (']|', '~]|')
+    (']|', ':~]|')
     ('|', '|https?://|')
     ()
 });
@@ -531,6 +533,8 @@ function InlineLexer(links, options) {
   } else if (this.options.pedantic) {
     this.rules = inline.pedantic;
   }
+
+  this.emojiTemplate = getEmojiTemplate(options);
 }
 
 /**
@@ -661,6 +665,13 @@ InlineLexer.prototype.output = function(src) {
       continue;
     }
 
+    // emoji (gfm)
+    if (cap = this.rules.emoji.exec(src)) {
+      src = src.substring(cap[0].length);
+      out += this.emoji(cap[1]);
+      continue;
+    }
+
     // text
     if (cap = this.rules.text.exec(src)) {
       src = src.substring(cap[0].length);
@@ -688,6 +699,47 @@ InlineLexer.prototype.outputLink = function(cap, link) {
   return cap[0].charAt(0) !== '!'
     ? this.renderer.link(href, title, this.output(cap[1]))
     : this.renderer.image(href, title, escape(cap[1]));
+};
+
+/**
+ * Emoji Transformations
+ */
+
+function emojiDefaultTemplate(emoji) {
+  return '<img src="'
+    + '/graphics/emojis/'
+    + encodeURIComponent(emoji)
+    + '.png"'
+    + ' alt=":'
+    + escape(emoji)
+    + ':"'
+    + ' title=":'
+    + escape(emoji)
+    + ':"'
+    + ' class="emoji" align="absmiddle" height="20" width="20">';
+}
+
+function getEmojiTemplate(options) {
+  if (options.emoji) {
+    if (typeof options.emoji === 'function') {
+      return options.emoji;
+    }
+
+    if (typeof options.emoji === 'string') {
+      var emojiSplit = options.emoji.split(/\{emoji\}/g);
+      return function(emoji) {
+        return emojiSplit.join(emoji);
+      }
+    }
+  }
+  return emojiDefaultTemplate;
+}
+
+InlineLexer.prototype.emojiTemplate = emojiDefaultTemplate;
+InlineLexer.prototype.emoji = function (name) {
+  if (!this.options.emoji) return ':' + name + ':';
+
+  return this.emojiTemplate(name);
 };
 
 /**
@@ -1208,6 +1260,7 @@ marked.setOptions = function(opt) {
 
 marked.defaults = {
   gfm: true,
+  emoji: false,
   tables: true,
   breaks: false,
   pedantic: false,

--- a/test/new/gfm_emoji.emoji.html
+++ b/test/new/gfm_emoji.emoji.html
@@ -1,0 +1,1 @@
+<p>note: we <img src="/graphics/emojis/heart.png" alt=":heart:" title=":heart:" class="emoji" align="absmiddle" height="20" width="20"> marked</p>

--- a/test/new/gfm_emoji.emoji.text
+++ b/test/new/gfm_emoji.emoji.text
@@ -1,0 +1,1 @@
+note: we :heart: marked

--- a/test/tests/gfm_emoji.emoji.html
+++ b/test/tests/gfm_emoji.emoji.html
@@ -1,0 +1,1 @@
+<p>note: we <img src="/graphics/emojis/heart.png" alt=":heart:" title=":heart:" class="emoji" align="absmiddle" height="20" width="20"> marked</p>

--- a/test/tests/gfm_emoji.emoji.text
+++ b/test/tests/gfm_emoji.emoji.text
@@ -1,0 +1,1 @@
+note: we :heart: marked


### PR DESCRIPTION
A simple implementation to work with emoji's like proposed in original #233 issue.

Unlike the complex idea mentioned in #233 this is a more elegant solution that only generates the replacement html code (or whatever you override as template). So no complicated data modules or funky stuff. 

Users will need to source and host the images for themselves, but can customise the template function to be as as simple or fancy as they require (examples provided).

Closes #233, work to solve https://github.com/isaacs/npm-www/issues/392
