### PR TITLE
Return the bullet string

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -296,6 +296,7 @@ Lexer.prototype.token = function(src, top) {
         // Remove the list item's bullet
         // so it is seen as the next token.
         space = item.length;
+        var li_bullet = block.bullet.exec(item)[0];
         item = item.replace(/^ *([*+-]|\d+\.) +/, '');
 
         // Outdent whatever the
@@ -329,7 +330,8 @@ Lexer.prototype.token = function(src, top) {
         this.tokens.push({
           type: loose
             ? 'loose_item_start'
-            : 'list_item_start'
+            : 'list_item_start',
+          bullet: li_bullet
         });
 
         // Recurse.


### PR DESCRIPTION
Since markdown supports different kinds of bullets, such as "-" and "+", it can be useful to see which one was used. We have used this to create a different markdown dialect in which different bullet types have different meanings.
