### PR TITLE
added wrap option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ marked.setOptions({
   sanitize: true,
   smartLists: true,
   smartypants: false,
-  langPrefix: 'lang-'
+  langPrefix: 'lang-',
+  wrap: true
 });
 
 // Using async version of marked
@@ -169,6 +170,16 @@ Type: `String`
 Default: `lang-`
 
 Set the prefix for code block classes.
+
+### wrap
+
+Type: `Boolean`
+Default: `true`
+
+Wrap the code block with `<pre><code>...</code></pre>`.
+If not set the `langPrefix` option is ignored and the `highlight` option
+can be used to generate custom wrapper.
+
 
 ## Access to lexer and parser
 

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -866,6 +866,10 @@ Parser.prototype.tok = function() {
         this.token.text = escape(this.token.text, true);
       }
 
+      if (!this.options.wrap) {
+        return this.token.text;
+      }
+
       return '<pre><code'
         + (this.token.lang
         ? ' class="'
@@ -1134,7 +1138,8 @@ marked.defaults = {
   silent: false,
   highlight: null,
   langPrefix: 'lang-',
-  smartypants: false
+  smartypants: false,
+  wrap: true,
 };
 
 /**

--- a/test/new/code.nowrap.html
+++ b/test/new/code.nowrap.html
@@ -1,0 +1,26 @@
+code block on the first line
+
+
+<p>Regular text.</p>
+
+code block indented by spaces
+
+
+<p>Regular text.</p>
+
+the lines in this block  
+all contain trailing spaces  
+
+
+<p>GFM Fences.</p>
+
+var a = &#39;hello&#39;;
+
+console.log(a + &#39; world&#39;);
+
+echo &quot;hello, ${WORLD}&quot;
+
+Q: What do you call a tall person who sells stolen goods?
+
+A longfence!
+

--- a/test/new/code.nowrap.text
+++ b/test/new/code.nowrap.text
@@ -1,0 +1,29 @@
+	code block on the first line
+	
+Regular text.
+
+    code block indented by spaces
+
+Regular text.
+
+	the lines in this block  
+	all contain trailing spaces  
+
+GFM Fences.
+
+``` js
+var a = 'hello';
+console.log(a + ' world');
+```
+
+~~~bash
+echo "hello, ${WORLD}"
+~~~
+
+```````longfence
+Q: What do you call a tall person who sells stolen goods?
+```````
+
+~~~~~~~~~~  ManyTildes
+A longfence!
+~~~~~~~~~~

--- a/test/tests/code.nowrap.html
+++ b/test/tests/code.nowrap.html
@@ -1,0 +1,26 @@
+code block on the first line
+
+
+<p>Regular text.</p>
+
+code block indented by spaces
+
+
+<p>Regular text.</p>
+
+the lines in this block  
+all contain trailing spaces  
+
+
+<p>GFM Fences.</p>
+
+var a = &#39;hello&#39;;
+
+console.log(a + &#39; world&#39;);
+
+echo &quot;hello, ${WORLD}&quot;
+
+Q: What do you call a tall person who sells stolen goods?
+
+A longfence!
+

--- a/test/tests/code.nowrap.text
+++ b/test/tests/code.nowrap.text
@@ -1,0 +1,29 @@
+	code block on the first line
+	
+Regular text.
+
+    code block indented by spaces
+
+Regular text.
+
+	the lines in this block  
+	all contain trailing spaces  
+
+GFM Fences.
+
+``` js
+var a = 'hello';
+console.log(a + ' world');
+```
+
+~~~bash
+echo "hello, ${WORLD}"
+~~~
+
+```````longfence
+Q: What do you call a tall person who sells stolen goods?
+```````
+
+~~~~~~~~~~  ManyTildes
+A longfence!
+~~~~~~~~~~


### PR DESCRIPTION
New option to control if code block is wrapped with pre/code elements. Default is true for backward compat.

Can be turned off to let the highlight function handle wrapping for custom layouts.
