### PR TITLE
add support for `lookupCodeLink` option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,18 @@ Type: `String`
 
 The callback function to call when using an async highlighter.
 
+### lookupCodeLink
+
+Type: `Function`
+
+An optional function for turning certain `` `code` `` blocks into links
+if there is an applicable reference for `"code"`.  The function receives
+the content of the backticks and must return a link object if there is
+an applicable reference, or undefined otherwise.  A link object must
+have an `href` property, and may have `text` and `title` properties.
+The `text` defaults to the given code.  The link has no title by
+default.
+
 ### tables
 
 Type: `Boolean`

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -653,6 +653,15 @@ InlineLexer.prototype.output = function(src) {
     // code
     if (cap = this.rules.code.exec(src)) {
       src = src.substring(cap[0].length);
+      if (this.options.lookupCodeLink) {
+        link = this.options.lookupCodeLink(cap[2]);
+        if (link && link.href) {
+          out += '<code>'
+            + this.outputLink(["", link.text || cap[2]], link)
+            + '</code>';
+          continue;
+        }
+      }
       out += '<code>'
         + escape(cap[2], true)
         + '</code>';

--- a/test/index.js
+++ b/test/index.js
@@ -61,8 +61,8 @@ function runTests(engine, options) {
     engine = null;
   }
 
-  var engine = engine || marked
-    , options = options || {}
+  engine = engine || marked;
+  var options = options || {}
     , files = options.files || load()
     , complete = 0
     , failed = 0
@@ -111,7 +111,13 @@ main:
     }
 
     try {
-      text = engine(file.text).replace(/\s/g, '');
+      text = engine(file.text, {
+        lookupCodeLink: function (name) {
+          if (name === "CodeReference") {
+            return {href: "#CodeReference"};
+          }
+        }
+      }).replace(/\s/g, '');
       html = file.html.replace(/\s/g, '');
     } catch(e) {
       console.log('%s failed.', filename);

--- a/test/tests/code_spans.html
+++ b/test/tests/code_spans.html
@@ -4,3 +4,5 @@
 
 <p>Here&#39;s how you put <code>`backticks`</code> in a code span.</p>
 
+<p><code><a href="#CodeReference">CodeReference</a></code> expanded by <code>options.lookupCodeLink</code>.</p>
+

--- a/test/tests/code_spans.text
+++ b/test/tests/code_spans.text
@@ -4,3 +4,5 @@ Fix for backticks within HTML tag: <span attr='`ticks`'>like this</span>
 
 Here's how you put `` `backticks` `` in a code span.
 
+`CodeReference` expanded by `options.lookupCodeLink`.
+


### PR DESCRIPTION
This would allow `marked` to create cross references for technical terms enquoted in back ticks if the user provides a lookup function that returns a link. The function may fall through if there is no corresponding link, and may be implemented using any data structure.
