### PR TITLE
Hook support for tokens

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -835,6 +835,11 @@ Parser.prototype.parseText = function() {
  */
 
 Parser.prototype.tok = function() {
+  var hooks = this.options.hooks
+    , hook = hooks && hooks[this.token.type];
+  if (hook) 
+    return hook(this.token, this);
+
   switch (this.token.type) {
     case 'space': {
       return '';


### PR DESCRIPTION
Added an ability to override some parser's tokens behavior. It may be useful, when generating a html for blog engines etc. I had the case when it expected for code blocks:

``` html
<!-- content -->
<source lang='javascript'> var a = 10 </source>
```

With the hook, this is trivial to implement:

``` javascript
marked(markdown, {
    hooks: {
        code: function(token) {

            return '<source '
                + (token.lang ? 'lang="' + token.lang + '"' : '')
                + '>\n'
                + token.text
                + '\n</source>'
                ;
        }
    }
});
```

In case you think this feature is not desired, simply close this pull request.

Cheers, Alex
