### PR TITLE
Add line break after code blocks

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -751,7 +751,7 @@ Renderer.prototype.code = function(code, lang, escaped, options) {
   if (!lang) {
     return '<pre><code>'
       + (escaped ? code : escape(code, true))
-      + '\n</code></pre>';
+      + '\n</code></pre>\n';
   }
 
   return '<pre><code class="'


### PR DESCRIPTION
All block-level elements have line break after close tag, but
indent-style code blocks does not. This bug appeared on [e3692c772b][1].

Input:

        Some pre formatted text.
        Other pre formatted text.
        Another pre formatted text.

    Normal paragraph.

Output:

    <pre><code>Some pre formatted text.
    Other pre formatted text.
    Another pre formatted text.</code></pre><p>Normal paragraph.</p>

[1]: https://github.com/chjj/marked/commit/e3692c772be8a8e12b53319baa7643fbd37ae666