### PR TITLE
Reimplement gfm breaks to actually match gfm

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -498,15 +498,6 @@ inline.gfm = merge({}, inline.normal, {
 });
 
 /**
- * GFM + Line Breaks Inline Grammar
- */
-
-inline.breaks = merge({}, inline.gfm, {
-  br: replace(inline.br)('{2,}', '*')(),
-  text: replace(inline.gfm.text)('{2,}', '*')()
-});
-
-/**
  * Inline Lexer & Compiler
  */
 
@@ -523,11 +514,7 @@ function InlineLexer(links, options) {
   }
 
   if (this.options.gfm) {
-    if (this.options.breaks) {
-      this.rules = inline.breaks;
-    } else {
-      this.rules = inline.gfm;
-    }
+    this.rules = inline.gfm;
   } else if (this.options.pedantic) {
     this.rules = inline.pedantic;
   }
@@ -1047,10 +1034,12 @@ Parser.prototype.tok = function() {
       return this.renderer.html(html);
     }
     case 'paragraph': {
-      return this.renderer.paragraph(this.inline.output(this.token.text));
+      var output = this.inline.output(this.token.text);
+      return this.renderer.paragraph(this.options.breaks ? output.replace(/\n/g,'<br>') : output);
     }
     case 'text': {
-      return this.renderer.paragraph(this.parseText());
+      var output = this.parseText();
+      return this.renderer.paragraph(this.options.breaks ? output.replace(/\n/g,'<br>') : output);
     }
   }
 };


### PR DESCRIPTION
gfm only does newline-to-br conversaion in a paragraph context. This change is aped from gfm source code.
