### PR TITLE
Feature footnotes

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -940,7 +940,7 @@ Renderer.prototype.image = function(href, title, text) {
 
 Renderer.prototype.footnoteref = function(key, count) {
   var out = '<sup class="footnote-ref" id="fnref-' + escape(key) + '">';
-  out += count + '</sup>';
+  out += '<a href="#fn-' + escape(key) + '">' + count + '</a></sup>';
   return out;
 };
 
@@ -949,6 +949,7 @@ Renderer.prototype.footnotes = function(notes) {
   for (var i = 0; i < notes.length; i++) {
     out += '<li id="fn-' + escape(notes[i].key) + '">';
     out += notes[i].text;
+    out += '<a href="#fnref-' + escape(notes[i].key) + '">&#8617;</a>'
     out += '</li>';
   }
   out += '</ol>';

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -93,7 +93,7 @@ block.tables = {
  * Footnotes Block Grammar
  */
 block.footnotes = {
-  footnote: /^\[(\^[^\]]+)\]: *([^\n]*(?:\n [^\n]*)*)/,
+  footnote: /^\[\^([^\]]+)\]: *([^\n]*(?:\n+|$)(?: {1,}[^\n]*(?:\n+|$))*)/
 };
 block.footnotes.normal = {
   footnote: block.footnotes.footnote

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -21,7 +21,8 @@ var block = {
   blockquote: /^( *>[^\n]+(\n[^\n]+)*\n*)+/,
   list: /^( *)(bull) [\s\S]+?(?:hr|\n{2,}(?! )(?!\1bull )\n*|\s*$)/,
   html: /^ *(?:comment|closed|closing) *(?:\n{2,}|\s*$)/,
-  def: /^ *\[([^\]]+)\]: *<?([^\s>]+)>?(?: +["(]([^\n]+)[")])? *(?:\n+|$)/,
+  def: /^ *\[([^^\]]+)\]: *<?([^\s>]+)>?(?: +["(]([^\n]+)[")])? *(?:\n+|$)/,
+  footnote: noop,
   table: noop,
   paragraph: /^((?:[^\n]+\n?(?!hr|heading|lheading|blockquote|tag|def))+)\n*/,
   text: /^[^\n]+/
@@ -73,7 +74,6 @@ block.gfm = merge({}, block.normal, {
   fences: /^ *(`{3,}|~{3,}) *(\S+)? *\n([\s\S]+?)\s*\1 *(?:\n+|$)/,
   paragraph: /^/
 });
-
 block.gfm.paragraph = replace(block.paragraph)
   ('(?!', '(?!'
     + block.gfm.fences.source.replace('\\1', '\\2') + '|'
@@ -81,13 +81,32 @@ block.gfm.paragraph = replace(block.paragraph)
   ();
 
 /**
- * GFM + Tables Block Grammar
+ * Tables Block Grammar
  */
 
-block.tables = merge({}, block.gfm, {
+block.tables = {
   nptable: /^ *(\S.*\|.*)\n *([-:]+ *\|[-| :]*)\n((?:.*\|.*(?:\n|$))*)\n*/,
   table: /^ *\|(.+)\n *\|( *[-:]+[-| :]*)\n((?: *\|.*(?:\n|$))*)\n*/
-});
+};
+
+/**
+ * Footnotes Block Grammar
+ */
+block.footnotes = {
+  footnote: /^\[(\^[^\]]+)\]: *([^\n]*(?:\n [^\n]*)*)/,
+};
+block.footnotes.normal = {
+  footnote: block.footnotes.footnote
+};
+block.footnotes.normal.paragraph = replace(block.paragraph)(
+  '))+)', '|' + block.footnotes.footnote.source + '))+)'
+)();
+block.footnotes.gfm = {
+  footnote: block.footnotes.footnote
+};
+block.footnotes.gfm.paragraph = replace(block.gfm.paragraph)(
+  '))+)', '|' + block.footnotes.footnote.source + '))+)'
+)();
 
 /**
  * Block Lexer
@@ -96,15 +115,21 @@ block.tables = merge({}, block.gfm, {
 function Lexer(options) {
   this.tokens = [];
   this.tokens.links = {};
+  this.tokens.footnotes = [];
   this.options = options || marked.defaults;
   this.rules = block.normal;
 
   if (this.options.gfm) {
-    if (this.options.tables) {
-      this.rules = block.tables;
-    } else {
-      this.rules = block.gfm;
+    this.rules = block.gfm;
+    if (this.options.footnotes) {
+      this.rules = merge({}, this.rules, block.footnotes.gfm);
     }
+  } else if (this.options.footnotes) {
+    this.rules = merge({}, this.rules, block.footnotes.normal);
+  }
+
+  if (this.options.tables) {
+    this.rules = merge({}, this.rules, block.tables);
   }
 }
 
@@ -144,6 +169,7 @@ Lexer.prototype.lex = function(src) {
 Lexer.prototype.token = function(src, top) {
   var src = src.replace(/^ +$/gm, '')
     , next
+    , key
     , loose
     , cap
     , bull
@@ -370,6 +396,15 @@ Lexer.prototype.token = function(src, top) {
       continue;
     }
 
+    // footnote
+    if (top && (cap = this.rules.footnote.exec(src))) {
+      src = src.substring(cap[0].length);
+      key = cap[1].toLowerCase();
+      this.tokens.footnotes.push({key: key, text: cap[2]});
+      this.tokens.footnotes[key] = {text: cap[2], count: this.tokens.footnotes.length};
+      continue;
+    }
+
     // table (gfm)
     if (top && (cap = this.rules.table.exec(src))) {
       src = src.substring(cap[0].length);
@@ -453,10 +488,11 @@ var inline = {
   code: /^(`+)\s*([\s\S]*?[^`])\s*\1(?!`)/,
   br: /^ {2,}\n(?!\s*$)/,
   del: noop,
+  footnote: noop,
   text: /^[\s\S]+?(?=[\\<!\[_*`]| {2,}\n|$)/
 };
 
-inline._inside = /(?:\[[^\]]*\]|[^\[\]]|\](?=[^\[]*\]))*/;
+inline._inside = /(?:\[[^^\]]*\]|[^\[\]]|\](?=[^\[]*\]))*/;
 inline._href = /\s*<?([\s\S]*?)>?(?:\s+['"]([\s\S]*?)['"])?\s*/;
 
 inline.link = replace(inline.link)
@@ -478,10 +514,10 @@ inline.normal = merge({}, inline);
  * Pedantic Inline Grammar
  */
 
-inline.pedantic = merge({}, inline.normal, {
+inline.pedantic = {
   strong: /^__(?=\S)([\s\S]*?\S)__(?!_)|^\*\*(?=\S)([\s\S]*?\S)\*\*(?!\*)/,
   em: /^_(?=\S)([\s\S]*?\S)_(?!_)|^\*(?=\S)([\s\S]*?\S)\*(?!\*)/
-});
+};
 
 /**
  * GFM Inline Grammar
@@ -507,12 +543,21 @@ inline.breaks = merge({}, inline.gfm, {
 });
 
 /**
+ * Footnote Inline Grammar
+ */
+
+inline.footnote = {
+  footnote: /^\[\^([^\]]+)\]/
+};
+
+/**
  * Inline Lexer & Compiler
  */
 
-function InlineLexer(links, options) {
+function InlineLexer(links, footnotes, options) {
   this.options = options || marked.defaults;
   this.links = links;
+  this.footnotes = footnotes || {};
   this.rules = inline.normal;
   this.renderer = this.options.renderer || new Renderer;
   this.renderer.options = this.options;
@@ -528,8 +573,14 @@ function InlineLexer(links, options) {
     } else {
       this.rules = inline.gfm;
     }
-  } else if (this.options.pedantic) {
-    this.rules = inline.pedantic;
+  }
+
+  if (this.options.footnote) {
+    this.rules = merge({}, this.rules, inline.footnote);
+  }
+
+  if (this.options.pedantic) {
+    this.rules = merge({}, this.rules, inline.pedantic);
   }
 }
 
@@ -543,8 +594,8 @@ InlineLexer.rules = inline;
  * Static Lexing/Compiling Method
  */
 
-InlineLexer.output = function(src, links, options) {
-  var inline = new InlineLexer(links, options);
+InlineLexer.output = function(src, links, footnotes, options) {
+  var inline = new InlineLexer(links, footnotes, options);
   return inline.output(src);
 };
 
@@ -555,6 +606,8 @@ InlineLexer.output = function(src, links, options) {
 InlineLexer.prototype.output = function(src) {
   var out = ''
     , link
+    , key
+    , ret
     , text
     , href
     , cap;
@@ -623,6 +676,16 @@ InlineLexer.prototype.output = function(src) {
         continue;
       }
       out += this.outputLink(cap, link);
+      continue;
+    }
+
+    // footnote
+    if (cap = this.rules.footnote.exec(src)) {
+      key = cap[1].toLowerCase();
+      if (ret = this.footnotes[key]) {
+        src = src.substring(cap[0].length);
+        out += this.renderer.footnoteref(key, ret.count);
+      }
       continue;
     }
 
@@ -875,6 +938,23 @@ Renderer.prototype.image = function(href, title, text) {
   return out;
 };
 
+Renderer.prototype.footnoteref = function(key, count) {
+  var out = '<sup class="footnote-ref" id="fnref-' + escape(key) + '">';
+  out += count + '</sup>';
+  return out;
+};
+
+Renderer.prototype.footnotes = function(notes) {
+  var out = '<ol class="footnotes">';
+  for (var i = 0; i < notes.length; i++) {
+    out += '<li id="fn-' + escape(notes[i].key) + '">';
+    out += notes[i].text;
+    out += '</li>';
+  }
+  out += '</ol>';
+  return out;
+};
+
 /**
  * Parsing & Compiling
  */
@@ -902,12 +982,16 @@ Parser.parse = function(src, options, renderer) {
  */
 
 Parser.prototype.parse = function(src) {
-  this.inline = new InlineLexer(src.links, this.options, this.renderer);
+  this.inline = new InlineLexer(src.links, src.footnotes, this.options);
   this.tokens = src.reverse();
 
   var out = '';
   while (this.next()) {
     out += this.tok();
+  }
+
+  if (src.footnotes.length) {
+    out += this.renderer.footnotes(src.footnotes);
   }
 
   return out;
@@ -1209,6 +1293,7 @@ marked.setOptions = function(opt) {
 marked.defaults = {
   gfm: true,
   tables: true,
+  footnotes: false,
   breaks: false,
   pedantic: false,
   sanitize: false,

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -399,7 +399,7 @@ Lexer.prototype.token = function(src, top) {
     // footnote
     if (top && (cap = this.rules.footnote.exec(src))) {
       src = src.substring(cap[0].length);
-      key = cap[1].toLowerCase();
+      key = cap[1].slice(1).toLowerCase();
       this.tokens.footnotes.push({key: key, text: cap[2]});
       this.tokens.footnotes[key] = {text: cap[2], count: this.tokens.footnotes.length};
       continue;
@@ -575,7 +575,7 @@ function InlineLexer(links, footnotes, options) {
     }
   }
 
-  if (this.options.footnote) {
+  if (this.options.footnotes) {
     this.rules = merge({}, this.rules, inline.footnote);
   }
 
@@ -654,6 +654,16 @@ InlineLexer.prototype.output = function(src) {
       continue;
     }
 
+    // footnote
+    if (cap = this.rules.footnote.exec(src)) {
+      key = cap[1].toLowerCase();
+      if (ret = this.footnotes[key]) {
+        src = src.substring(cap[0].length);
+        out += this.renderer.footnoteref(key, ret.count);
+        continue;
+      }
+    }
+
     // link
     if (cap = this.rules.link.exec(src)) {
       src = src.substring(cap[0].length);
@@ -676,16 +686,6 @@ InlineLexer.prototype.output = function(src) {
         continue;
       }
       out += this.outputLink(cap, link);
-      continue;
-    }
-
-    // footnote
-    if (cap = this.rules.footnote.exec(src)) {
-      key = cap[1].toLowerCase();
-      if (ret = this.footnotes[key]) {
-        src = src.substring(cap[0].length);
-        out += this.renderer.footnoteref(key, ret.count);
-      }
       continue;
     }
 


### PR DESCRIPTION
Footnotes feature. It looks like MultiMarkdown Footnotes Syntax:

```
Here is some text containing a footnote.[^somesamplefootnote]

[^somesamplefootnote]: Here is the text of the footnote itself.
```
- http://daringfireball.net/2005/07/footnotes
- https://github.com/fletcher/MultiMarkdown/wiki/MultiMarkdown-Syntax-Guide#wiki-footnotes
- http://six.pairlist.net/pipermail/markdown-discuss/2005-August/001442.html
- http://six.pairlist.net/pipermail/markdown-discuss/2005-August/001480.html

Related Issue: https://github.com/chjj/marked/issues/27

@chjj Have a review of this patch. I will add test cases soon.
