### PR TITLE
Don't require a newline at the end of a task list

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -76,7 +76,7 @@ block.normal = merge({}, block);
  */
 
 block.gfm = merge({}, block.normal, {
-  task: /^(\s*\[[x ]\][^\n]+\n)+\n*/,
+  task: /^(\s*\[[x ]\][^\n]+(\n|$))+\n*/,
   fences: /^ *(`{3,}|~{3,}) *(\S+)? *\n([\s\S]+?)\s*\1 *(?:\n+|$)/,
   paragraph: /^/
 });


### PR DESCRIPTION
FIxed the case where you have something like this:

    "[ ] One\n[ ] Two\n[x] Three"

with no trailing newline.