### PR TITLE
Allow un-closed fenced code blocks

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -75,7 +75,7 @@ block.normal = merge({}, block);
  */
 
 block.gfm = merge({}, block.normal, {
-  fences: /^ *(`{3,}|~{3,}) *(\S+)? *\n([\s\S]+?)\s*\1 *(?:\n+|$)/,
+  fences: /^ *(`{3,}|~{3,}) *(\S+)? *\n(?:(?:([\s\S]+?)\s*\1 *(?:\n+|$))|([\s\S]*$))/,
   paragraph: /^/
 });
 
@@ -188,7 +188,7 @@ Lexer.prototype.token = function(src, top, bq) {
       this.tokens.push({
         type: 'code',
         lang: cap[2],
-        text: cap[3]
+        text: cap[3] || cap[4]
       });
       continue;
     }

--- a/test/new/gfm_code.html
+++ b/test/new/gfm_code.html
@@ -3,3 +3,4 @@ console.log(a + &#39; world&#39;);</code></pre>
 <pre><code class="lang-bash">echo &quot;hello, ${WORLD}&quot;</code></pre>
 <pre><code class="lang-longfence">Q: What do you call a tall person who sells stolen goods?</code></pre>
 <pre><code class="lang-ManyTildes">A longfence!</code></pre>
+<pre><code class="lang-noclose">A code block with no closing codefence.</code></pre>

--- a/test/new/gfm_code.text
+++ b/test/new/gfm_code.text
@@ -14,3 +14,6 @@ Q: What do you call a tall person who sells stolen goods?
 ~~~~~~~~~~  ManyTildes
 A longfence!
 ~~~~~~~~~~
+
+`````` noclose
+A code block with no closing codefence.

--- a/test/tests/gfm_code.html
+++ b/test/tests/gfm_code.html
@@ -3,3 +3,4 @@ console.log(a + &#39; world&#39;);</code></pre>
 <pre><code class="lang-bash">echo &quot;hello, ${WORLD}&quot;</code></pre>
 <pre><code class="lang-longfence">Q: What do you call a tall person who sells stolen goods?</code></pre>
 <pre><code class="lang-ManyTildes">A longfence!</code></pre>
+<pre><code class="lang-noclose">A code block with no closing codefence.</code></pre>

--- a/test/tests/gfm_code.text
+++ b/test/tests/gfm_code.text
@@ -14,3 +14,6 @@ Q: What do you call a tall person who sells stolen goods?
 ~~~~~~~~~~  ManyTildes
 A longfence!
 ~~~~~~~~~~
+
+`````` noclose
+A code block with no closing codefence.


### PR DESCRIPTION
This fixes https://github.com/atom/markdown-preview/issues/13

In GFM, if you open a fenced code block and never close it -- a code block is created that spans until the end of the file. I have to admit that it's arguable if this is a bug or a feature, but since that behavior in GFM is not likely to change soon and people seem to rely on it -- it makes sense to match it in marked.

Currently, marked creates a code block only if both an opening and a closing codefence is found. So, this PR 
* changes the `fences` regex so that it detects fenced code blocks even if no closing codefence is found
* adds tests to verify the new behavior