### PR TITLE
Handle renderer arguments in Parser constructor

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -893,11 +893,11 @@ Renderer.prototype.image = function(href, title, text) {
  * Parsing & Compiling
  */
 
-function Parser(options) {
+function Parser(options, renderer) {
   this.tokens = [];
   this.token = null;
   this.options = options || marked.defaults;
-  this.options.renderer = this.options.renderer || new Renderer;
+  this.options.renderer = renderer || this.options.renderer || new Renderer;
   this.renderer = this.options.renderer;
   this.renderer.options = this.options;
 }


### PR DESCRIPTION
`Parser.parse` was calling `Parser` with `Parser(options, renderer)` but the constructor didn't handle it. So I just tweaked the constructor so that it now accepts the `renderer` argument.
