### PR TITLE
use SVG to display npm module's version

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A full-featured markdown parser and compiler, written in JavaScript. Built
 > for speed.
 
-[![NPM version](https://badge.fury.io/js/marked.png)][badge]
+[![NPM version](https://badge.fury.io/js/marked.svg)][badge]
 
 ## Install
 


### PR DESCRIPTION
Rationale:
- SVG looks better on mobile devices with high pixel density
- SVG file size is smaller
