### PR TITLE
Html structure

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -156,6 +156,7 @@ Lexer.prototype.token = function(src, top, bq) {
     , item
     , space
     , i
+    , re
     , l;
 
   while (src) {
@@ -354,14 +355,27 @@ Lexer.prototype.token = function(src, top, bq) {
 
     // html
     if (cap = this.rules.html.exec(src)) {
-      src = src.substring(cap[0].length);
-      this.tokens.push({
+      item = {
         type: this.options.sanitize
           ? 'paragraph'
           : 'html',
         pre: cap[1] === 'pre' || cap[1] === 'script' || cap[1] === 'style',
-        text: cap[0]
-      });
+      };
+      if (cap[1]) {
+        i = 1;
+        re = new RegExp('<(/' + cap[1] + '|' + cap[1] + '(?:"[^"]*"|\'[^\']*\'|[^\'">])*?/?)>', 'g');
+        // move past the opening tag found by this.rules.html
+        re.exec(src);
+        while (i > 0) {
+          cap = re.exec(src);
+          i += cap[1].charAt(0) === '/' ? -1 : cap[1].charAt(cap[1].length - 1) === '/' ? 0 : 1;
+        }
+        item.text = src.substring(0, re.lastIndex);
+      } else {
+        item.text = cap[0];
+      }
+      src = src.substring(item.text.length);
+      this.tokens.push(item);
       continue;
     }
 

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -55,6 +55,10 @@ block.html = replace(block.html)
   (/tag/g, block._tag)
   ();
 
+block._htmlEndTag = replace('</?(tag)[\\s\\S]+?<(/\\1|\\1(?:"[^"]*"|\'[^\']*\'|[^\'">])*?/?)>', 'g')
+  ('tag', block._tag)
+  ();
+
 block.paragraph = replace(block.paragraph)
   ('hr', block.hr)
   ('heading', block.heading)
@@ -363,12 +367,15 @@ Lexer.prototype.token = function(src, top, bq) {
       };
       if (cap[1]) {
         i = 1;
-        re = new RegExp('<(/' + cap[1] + '|' + cap[1] + '(?:"[^"]*"|\'[^\']*\'|[^\'">])*?/?)>', 'g');
-        // move past the opening tag found by this.rules.html
-        re.exec(src);
-        while (i > 0) {
+        re = this.rules._htmlEndTag;
+        re.lastIndex = 0;
+        // /</?(tag)/?>.*<(/\1|\1(?:"[^"]*"|\'[^\']*\'|[^\'">])*?/?)>/g
+        while (i) {
           cap = re.exec(src);
-          i += cap[1].charAt(0) === '/' ? -1 : cap[1].charAt(cap[1].length - 1) === '/' ? 0 : 1;
+          i += cap[2].charAt(0) === '/' ? -1 : cap[2].charAt(cap[2].length - 1) === '/' ? 0 : 1;
+          if (i) {
+            re.lastIndex = re.lastIndex - (cap[2].length + 2);
+          }
         }
         item.text = src.substring(0, re.lastIndex);
       } else {
@@ -1110,7 +1117,7 @@ function unescape(html) {
 }
 
 function replace(regex, opt) {
-  regex = regex.source;
+  regex = regex.source || regex;
   opt = opt || '';
   return function self(name, val) {
     if (!name) return new RegExp(regex, opt);

--- a/package.json
+++ b/package.json
@@ -18,5 +18,5 @@
     "showdown": "*",
     "robotskirt": "*"
   },
-  "scripts": { "test": "node test", "bench": "node test --bench" }
+  "scripts": { "test": "node test; node test/lexer", "bench": "node test --bench" }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -193,7 +193,7 @@ function bench(name, func) {
   }
 
   var start = Date.now()
-    , times = 50000
+    , times = 1000
     , keys = Object.keys(files)
     , i
     , l = keys.length

--- a/test/index.js
+++ b/test/index.js
@@ -193,7 +193,7 @@ function bench(name, func) {
   }
 
   var start = Date.now()
-    , times = 1000
+    , times = 50000
     , keys = Object.keys(files)
     , i
     , l = keys.length

--- a/test/lexer/index.js
+++ b/test/lexer/index.js
@@ -1,0 +1,31 @@
+var marked = require('../../'),
+    fs = require('fs'),
+    path = require('path');
+var tests = [], failed = 0;
+var test = tests.push;
+
+test(function() {
+  var content = fs.readFileSync(path.join(__dirname, './resources/complex_html.md'), 'utf8');
+  var nodes = marked.lexer(content);
+  assertEqual('heading', nodes[0].type);
+  assertEqual('html', nodes[1].type);
+  assertEqual('<div>\nThis HTML has\n<div>\nNested Divs\n</div>\n\n<div>\nIn a messy structure\n</div>\n\n</div>', nodes[1].text);
+  assertEqual(2, nodes.length);
+});
+
+function assertEqual(expected, actual) {
+  if (expected !== actual) {
+    throw "Expected: "+expected+"\nActual: "+actual;
+  }
+}
+
+console.log('\nLexer tests\n-----------');
+tests.forEach(function(t) {
+  try {
+    t();
+  } catch(e) {
+    console.log("Failed:", e);
+    failed += 1;
+  }
+});
+console.log(failed === 0 ? 'All tests passed' : failed + ' tests failed');

--- a/test/lexer/resources/complex_html.md
+++ b/test/lexer/resources/complex_html.md
@@ -1,0 +1,13 @@
+# A markdown file with complex HTML
+
+<div>
+This HTML has
+<div>
+Nested Divs
+</div>
+
+<div>
+In a messy structure
+</div>
+
+</div>


### PR DESCRIPTION
Following on from #406, this has been updated to use a static regex.

I ran the bench tests for this PR and v0.3.2 (50000 iterations) and there doesn't seem to be any significant difference:

|  | v0.3.2 | This PR |
| --- | --- | --- |
| marked | 171160ms | 169728ms. |
| marked (gfm) | 186709ms | 188834ms. |
| marked (pedantic) | 161621ms | 161455ms. |
