### PR TITLE
Move CLI usage up on README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ marked.setOptions({
 console.log(marked('I am using __markdown__.'));
 ```
 
+### CLI
+
+``` bash
+$ marked -o hello.html
+hello world
+^D
+$ cat hello.html
+<p>hello world</p>
+```
+
 ## marked(markdownString [,options] [,callback])
 
 ### markdownString
@@ -261,16 +271,6 @@ var lexer = new marked.Lexer(options);
 var tokens = lexer.lex(text);
 console.log(tokens);
 console.log(lexer.rules);
-```
-
-## CLI
-
-``` bash
-$ marked -o hello.html
-hello world
-^D
-$ cat hello.html
-<p>hello world</p>
 ```
 
 ## Philosophy behind marked


### PR DESCRIPTION
- this is one of the first thing new users will want to know
- makes it clear that there is a CLI interface
- CLI section is much shorter than the full function documentation, and gets hidden by it if it comes afterwards
