### PR TITLE
add support for #fragment links in <autolinks>

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -447,7 +447,7 @@ Lexer.prototype.token = function(src, top, bq) {
 
 var inline = {
   escape: /^\\([\\`*{}\[\]()#+\-.!_>])/,
-  autolink: /^<([^ >]+(@|:\/)[^ >]+)>/,
+  autolink: /^<([^ >]+(@|:\/)[^ >]+|#([^ >]*))>/,
   url: noop,
   tag: /^<!--[\s\S]*?-->|^<\/?\w+(?:"[^"]*"|'[^']*'|[^'">])*?>/,
   link: /^!?\[(inside)\]\(href\)/,


### PR DESCRIPTION
Allow #fragment links in the `<http://somwhere.com>` link syntax, e.g. `<#Section4>`.
