### PR TITLE
README: Document xhtml option; fix two spelling errors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ marked.setOptions({
   pedantic: false,
   sanitize: true,
   smartLists: true,
-  smartypants: false
+  smartypants: false,
+  xhtml: false
 });
 
 console.log(marked('I am using __markdown__.'));
@@ -245,7 +246,14 @@ default with the old behavior moved into `pedantic`.
 Type: `boolean`
 Default: `false`
 
-Use "smart" typograhic punctuation for things like quotes and dashes.
+Use "smart" typographic punctuation for things like quotes and dashes.
+
+### xhtml
+
+Type: `boolean`
+Default: `false`
+
+Add a trailing slash to elements like `br`, `hr`, and `img`.
 
 ## Access to lexer and parser
 
@@ -277,7 +285,7 @@ $ cat hello.html
 
 The point of marked was to create a markdown compiler where it was possible to
 frequently parse huge chunks of markdown without having to worry about
-caching the compiled output somehow...or blocking for an unnecesarily long time.
+caching the compiled output somehow...or blocking for an unnecessarily long time.
 
 marked is very concise and still implements all markdown features. It is also
 now fully compatible with the client-side.


### PR DESCRIPTION
Wanting XHTML-compliance, I started to add my own "xhtml" option before I realized one was already present. Issue #234 makes it sound like this feature was a little controversial - but the support is in the code, so I thought it would be good to mention it in the README.

While making that change, I noticed two small misspellings and corrected them.
