### PR TITLE
IDs of headings with inline tokens (link, em, bold...)

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -936,7 +936,7 @@ Parser.parse = function(src, options) {
  */
 
 Parser.prototype.parse = function(src) {
-  this.inline = new InlineLexer(src.links, this.options, this.renderer);
+  this.inline = new InlineLexer(src.links, this.options);
   this.tokens = src.reverse();
 
   var out = '';

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1326,6 +1326,7 @@ marked.Parser = Parser;
 marked.parser = Parser.parse;
 
 marked.Renderer = Renderer;
+marked.TextRenderer = TextRenderer;
 
 marked.Lexer = Lexer;
 marked.lexer = Lexer.lex;

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -910,6 +910,32 @@ Renderer.prototype.text = function(text) {
 };
 
 /**
+ * TextRenderer
+ * returns only the textual part of the token
+ */
+
+function TextRenderer() {}
+
+// no need for block level renderers
+
+TextRenderer.prototype.strong =
+TextRenderer.prototype.em =
+TextRenderer.prototype.codespan =
+TextRenderer.prototype.del =
+TextRenderer.prototype.text = function (text) {
+  return text;
+}
+
+TextRenderer.prototype.link =
+TextRenderer.prototype.image = function(href, title, text) {
+  return '' + text;
+}
+
+TextRenderer.prototype.br = function() {
+  return '';
+}
+
+/**
  * Parsing & Compiling
  */
 
@@ -937,6 +963,8 @@ Parser.parse = function(src, options) {
 
 Parser.prototype.parse = function(src) {
   this.inline = new InlineLexer(src.links, this.options);
+  // use an InlineLexer with a TextRenderer to extract pure text
+  this.inlineText = new InlineLexer(src.links, merge({}, this.options, {renderer: new TextRenderer}));
   this.tokens = src.reverse();
 
   var out = '';
@@ -993,7 +1021,7 @@ Parser.prototype.tok = function() {
       return this.renderer.heading(
         this.inline.output(this.token.text),
         this.token.depth,
-        this.token.text);
+        unescape(this.inlineText.output(this.token.text)));
     }
     case 'code': {
       return this.renderer.code(this.token.text,

--- a/test/new/headings-id.html
+++ b/test/new/headings-id.html
@@ -1,0 +1,13 @@
+<h3 id="heading-with-a-link">Heading with a <a href="http://github.com/">link</a></h3>
+
+<h3 id="heading-with-some-italic-text">Heading with some <em>italic text</em></h3>
+
+<h3 id="or-some-strong">Or some <strong>strong</strong></h3>
+
+<p>(which doesn&#39;t really make any difference, here)</p>
+
+<h3 id="or-even-code">Or even <code>code</code></h3>
+
+<h3 id="what-about-strikethrough">What about <del>strikethrough</del></h3>
+
+<h2 id="and-a-ref-link">And a ref <a href="/some/url" title="link to nowhere">link</a></h2>

--- a/test/new/headings-id.md
+++ b/test/new/headings-id.md
@@ -1,0 +1,14 @@
+### Heading with a [link](http://github.com/)
+
+### Heading with some _italic text_
+
+### Or some **strong**
+(which doesn't really make any difference, here)
+
+### Or even `code`
+
+### What about ~~strikethrough~~
+
+## And a ref [link][destination]
+
+[destination]: /some/url "link to nowhere"

--- a/test/new/links_reference_style.html
+++ b/test/new/links_reference_style.html
@@ -48,7 +48,7 @@
 <p>[bar]</p>
 
 <p>However, it can directly follow other block elements, such as headings</p>
-<h1 id="-foo-"><a href="/url">Foo</a></h1>
+<h1 id="foo"><a href="/url">Foo</a></h1>
 <blockquote>
 <p>bar</p>
 </blockquote>


### PR DESCRIPTION
PR for #450

I hope it doesn't seem overkilling, I kept it as small as possible.
Comments are welcome. I'll be posting some tests, if I can manage to make them work.

Meanwhile I tested it with

``` markdown
### Heading with a [link](http://github.com/)

### Heading with some _italic text_

### Or some **strong**
(which doesn't really make any difference, here)

### Or even `code`

### What about ~~strikethrough~~
```

and I got

``` html
<h3 id="heading-with-a-link">Heading with a <a href="http://github.com/">link</a></h3>
<h3 id="heading-with-some-italic-text">Heading with some <em>italic text</em></h3>
<h3 id="or-some-strong">Or some <strong>strong</strong></h3>
<p>(which doesn&#39;t really make any difference, here)</p>
<h3 id="or-even-code">Or even <code>code</code></h3>
<h3 id="what-about-strikethrough">What about <del>strikethrough</del></h3>
```

which looks good to me.

Fixes #450, fixes #510 