### PR TITLE
Trim excess dashes from heading IDs

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -790,7 +790,7 @@ Renderer.prototype.heading = function(text, level, raw) {
     + level
     + ' id="'
     + this.options.headerPrefix
-    + raw.toLowerCase().replace(/[^\w]+/g, '-')
+    + raw.toLowerCase().replace(/[^\w]+/g, '-').replace(/^\-+|\-+$/g, '')
     + '">'
     + text
     + '</h'


### PR DESCRIPTION
When I have something like

```
# Heading with some trailing punctuation...
```

With the default Renderer I get

``` html
<h1 id="heading-with-some-trailing-punctuation-">Heading with some trailing punctuation...</h1>
```

(notice the trailing dash in the id).
This PR fixes this:

``` html
<h1 id="heading-with-some-trailing-punctuation">Heading with some trailing punctuation...</h1>
```

**Warning**: this may change the way URLs are generated and break existing links.
