### PR TITLE
Footnote ref "uniquefier" fix

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -906,7 +906,7 @@ Renderer.prototype.footnote = function(ref, body) {
   return '<li id="fn' + ref + '">' + body
     + '<a href="#fnref' + ref + '" class="footnoteBackLink" '
     + 'title="Jump back to footnote ' + ref
-    + ' in the text.">↩</a>'
+    + ' in the text.">&#8617;</a>'
     + '</li>\n';
 };
 

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -898,14 +898,14 @@ Renderer.prototype.del = function(text) {
 
 Renderer.prototype.footnoteref = function(ref) {
   return '<sup id="fnref' + ref + '">'
-    + '<a href="#fn' + ref + '">' + ref + '</a>'
+    + '<a href="#fn' + ref + '">' + ref.split("-")[0] + '</a>'
     + '</sup>';
 };
 
 Renderer.prototype.footnote = function(ref, body) {
   return '<li id="fn' + ref + '">' + body
     + '<a href="#fnref' + ref + '" class="footnoteBackLink" '
-    + 'title="Jump back to footnote ' + ref
+    + 'title="Jump back to footnote ' + ref.split("-")[0]
     + ' in the text.">&#8617;</a>'
     + '</li>\n';
 };


### PR DESCRIPTION
Good day! It is simple patch which fixes problem with "unique" references many bloggers use for footnotes to void footnote reference overlapping. John Grubber does add a post date after footnote sequence number like `[^1-2014-07-31]` to avoid such problems. This patch preserves unique reference for link and back link bt does render correct number for footnote sequence. Thanks!