### PR TITLE
Use the correct default value for "sanitize" in the README example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ marked.setOptions({
   tables: true,
   breaks: false,
   pedantic: false,
-  sanitize: true,
+  sanitize: false,
   smartLists: true,
   smartypants: false
 });


### PR DESCRIPTION
The text in the README implies that the default options are being shown, but the default option for sanitize is "false". Showing "true" could mistakenly lead a user to assume that they don't need to enable the sanitize option.
