### PR TITLE
Support HTML start tags with new-lines in them.

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -447,7 +447,7 @@ Lexer.prototype.token = function(src, top, bq) {
 
 var inline = {
   escape: /^\\([\\`*{}\[\]()#+\-.!_>])/,
-  autolink: /^<([^ >]+(@|:\/)[^ >]+)>/,
+  autolink: /^<([^\s>]+(@|:\/)[^\s>]+)>/,
   url: noop,
   tag: /^<!--[\s\S]*?-->|^<\/?\w+(?:"[^"]*"|'[^']*'|[^'">])*?>/,
   link: /^!?\[(inside)\]\(href\)/,

--- a/test/new/html_tag_newline.html
+++ b/test/new/html_tag_newline.html
@@ -1,0 +1,2 @@
+<p><a
+href="http://example.com">world</a></p>

--- a/test/new/html_tag_newline.text
+++ b/test/new/html_tag_newline.text
@@ -1,0 +1,2 @@
+<a
+href="http://example.com">world</a>

--- a/test/tests/html_tag_newline.html
+++ b/test/tests/html_tag_newline.html
@@ -1,0 +1,2 @@
+<p><a
+href="http://example.com">world</a></p>

--- a/test/tests/html_tag_newline.text
+++ b/test/tests/html_tag_newline.text
@@ -1,0 +1,2 @@
+<a
+href="http://example.com">world</a>


### PR DESCRIPTION
HTML5 Start tags can contain "one or more space characters" (8.1.2.1 #3).

A "space character" is space, tab, LF, FF or CR (2.4.1).

This change makes marked support any Unicode white space in tags by restricting
the autolink to not contain any /\s/ character. It is slightly more permissive
than the HTML5 standard, but that is unlikely to be a problem in practice.
