### PR TITLE
create tokens for encountered link definitions

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -372,6 +372,11 @@ Lexer.prototype.token = function(src, top, bq) {
         href: cap[2],
         title: cap[3]
       };
+      this.tokens.push({
+        type: 'def',
+        href: cap[2],
+        title: cap[3]
+      });
       continue;
     }
 
@@ -781,6 +786,10 @@ Renderer.prototype.blockquote = function(quote) {
   return '<blockquote>\n' + quote + '</blockquote>\n';
 };
 
+Renderer.prototype.def = function(href, title) {
+  return '';
+};
+
 Renderer.prototype.html = function(html) {
   return html;
 };
@@ -965,6 +974,11 @@ Parser.prototype.tok = function() {
   switch (this.token.type) {
     case 'space': {
       return '';
+    }
+    case 'def': {
+      return this.renderer.def(
+        this.token.href,
+        this.token.title);
     }
     case 'hr': {
       return this.renderer.hr();

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -368,12 +368,14 @@ Lexer.prototype.token = function(src, top, bq) {
     // def
     if ((!bq && top) && (cap = this.rules.def.exec(src))) {
       src = src.substring(cap[0].length);
-      this.tokens.links[cap[1].toLowerCase()] = {
+      var id = cap[1].toLowerCase();
+      this.tokens.links[id] = {
         href: cap[2],
         title: cap[3]
       };
       this.tokens.push({
         type: 'def',
+        id: id,
         href: cap[2],
         title: cap[3]
       });
@@ -786,7 +788,7 @@ Renderer.prototype.blockquote = function(quote) {
   return '<blockquote>\n' + quote + '</blockquote>\n';
 };
 
-Renderer.prototype.def = function(href, title) {
+Renderer.prototype.def = function(id, href, title) {
   return '';
 };
 
@@ -977,6 +979,7 @@ Parser.prototype.tok = function() {
     }
     case 'def': {
       return this.renderer.def(
+        this.token.id,
         this.token.href,
         this.token.title);
     }


### PR DESCRIPTION
The Eclipse project's Orion [1] markdown editor uses marked both to generate HTML content and to identify the regions in the .md source for syntax styling.  Marked's current lack of generated tokens for encountered link definitions makes it impossible for Orion's editor to reliably identify the regions following a link definition.

This pull request creates tokens for encountered link definitions.  These tokens do not affect the generated output in any way, but enable a client of marked's lexer to know the link definition's character range, which is the only missing piece to complete mapping from the .md source to the generated .html.

[1] https://orionhub.org/
