### PR TITLE
Fix to heading regular expression for GFM #201.

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -76,7 +76,8 @@ block.normal = merge({}, block);
 
 block.gfm = merge({}, block.normal, {
   fences: /^ *(`{3,}|~{3,}) *(\S+)? *\n([\s\S]+?)\s*\1 *(?:\n+|$)/,
-  paragraph: /^/
+  paragraph: /^/,
+  heading: /^ *(#{1,6}) +([^\n]+?) *#* *(?:\n+|$)/
 });
 
 block.gfm.paragraph = replace(block.paragraph)

--- a/test/new/gfm_hashtag.gfm.html
+++ b/test/new/gfm_hashtag.gfm.html
@@ -1,0 +1,5 @@
+<p>#header</p>
+
+<h1 id="header1">header1</h1>
+
+<h1 id="header2">header2</h1>

--- a/test/new/gfm_hashtag.gfm.text
+++ b/test/new/gfm_hashtag.gfm.text
@@ -1,0 +1,5 @@
+#header
+
+# header1
+
+#  header2

--- a/test/new/gfm_hashtag.nogfm.html
+++ b/test/new/gfm_hashtag.nogfm.html
@@ -1,0 +1,5 @@
+<h1 id="header">header</h1>
+
+<h1 id="header1">header1</h1>
+
+<h1 id="header2">header2</h1>

--- a/test/new/gfm_hashtag.nogfm.text
+++ b/test/new/gfm_hashtag.nogfm.text
@@ -1,0 +1,5 @@
+#header
+
+# header1
+
+#  header2

--- a/test/tests/gfm_hashtag.gfm.html
+++ b/test/tests/gfm_hashtag.gfm.html
@@ -1,0 +1,5 @@
+<p>#header</p>
+
+<h1 id="header1">header1</h1>
+
+<h1 id="header2">header2</h1>

--- a/test/tests/gfm_hashtag.gfm.text
+++ b/test/tests/gfm_hashtag.gfm.text
@@ -1,0 +1,5 @@
+#header
+
+# header1
+
+#  header2

--- a/test/tests/gfm_hashtag.nogfm.html
+++ b/test/tests/gfm_hashtag.nogfm.html
@@ -1,0 +1,5 @@
+<h1 id="header">header</h1>
+
+<h1 id="header1">header1</h1>
+
+<h1 id="header2">header2</h1>

--- a/test/tests/gfm_hashtag.nogfm.text
+++ b/test/tests/gfm_hashtag.nogfm.text
@@ -1,0 +1,5 @@
+#header
+
+# header1
+
+#  header2


### PR DESCRIPTION
Do not encode `#hashtag` (no white space) at GFM mode.