### PR TITLE
Adding support for registering new block or inline rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # marked
 
 > A full-featured markdown parser and compiler, written in JavaScript. Built
-> for speed.
+> for speed, and a dash of extensibility.
 
 [![NPM version](https://badge.fury.io/js/marked.png)][badge]
 
@@ -315,22 +315,30 @@ features][gfmf].
 
 ## Benchmarks
 
+Run from my MacBook Pro (13-inch, Mid 2010), 2.4 GHz Intel Core 2 Duo, 16 GB 1067 MHz DDR3
+
+We lose some performance to add in the register rule feature, enough to change the direction of marked I think.
+
 node v0.8.x
 
 ``` bash
 $ node test --bench
-marked completed in 3411ms.
-marked (gfm) completed in 3727ms.
-marked (pedantic) completed in 3201ms.
-robotskirt completed in 808ms.
-showdown (reuse converter) completed in 11954ms.
-showdown (new converter) completed in 17774ms.
-markdown-js completed in 17191ms.
+Original marked run from my machine
+marked completed in 5270ms.
+marked (gfm) completed in 5671ms.
+marked (pedantic) completed in 4782ms.
+
+Extensible marked run from my machine
+marked completed in 6988ms.
+marked (gfm) completed in 7422ms.
+marked (pedantic) completed in 6363ms.
+
+Rest of the bench tests run from my machine
+robotskirt completed in 1050ms.
+showdown (reuse converter) completed in 18354ms.
+showdown (new converter) completed in 26976ms.
+markdown.js completed in 24554ms.
 ```
-
-__Marked is now faster than Discount, which is written in C.__
-
-For those feeling skeptical: These benchmarks run the entire markdown test suite 1000 times. The test suite tests every feature. It doesn't cater to specific aspects.
 
 ### Pro level
 

--- a/demo.html
+++ b/demo.html
@@ -1,0 +1,223 @@
+
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>commonmark.js demo</title>
+  <script src="http://code.jquery.com/jquery-1.11.0.min.js"></script>
+  <script src="http://maxcdn.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
+  <link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css" rel="stylesheet">
+  <script src="http://spec.commonmark.org/js/commonmark.js"></script>
+  <script src="lib/marked.js"></script>
+  <script type="text/javascript">
+
+var writer = new commonmark.HtmlRenderer();
+var reader = new commonmark.DocParser();
+
+function getQueryVariable(variable)
+{
+       var query = window.location.search.substring(1);
+       var vars = query.split("&");
+       for (var i=0;i<vars.length;i++) {
+               var pair = vars[i].split("=");
+               if(pair[0] == variable){return decodeURIComponent(pair[1]);}
+       }
+       return null;
+}
+
+
+$(document).ready(function() {
+  var timer;
+  var x;
+  var parsed;
+  var render = function() {
+      if (parsed === undefined) {
+        return;
+      }
+      var startTime = new Date().getTime();
+      var result = writer.renderBlock(parsed);
+      var endTime = new Date().getTime();
+      var renderTime = endTime - startTime;
+      // $("#html").text(result);
+      $("#preview").html(result);
+      $("#html").text(result);
+      $("#ast").text(commonmark.ASTRenderer(parsed));
+      $("#rendertime").text(renderTime);
+  };
+  var _rule = {
+    positionFromEnd: 1,
+    regExp: /\$\$\$/,
+    name: 'myNewRule',
+    parser: function() {
+      return this.renderer.myNewRule(this.token.text);
+    },
+    renderer: function(text) {
+      return 'Three ' + text + ' Dollars';
+    },
+    type: 'inline',
+    action: function(outputVars) {
+      if (outputVars.cap = this.rules.myNewRule.exec(outputVars.src)) {
+        outputVars.src = outputVars.src.substring(outputVars.cap[0].length);
+        outputVars.out += this.renderer.myNewRule(outputVars.cap[0]);
+
+        return true;
+      }
+
+      return false;
+    }
+  }
+  //marked.registerRule(_rule);
+  var parseAndRender = function () {
+// var renderer = new marked.Renderer();
+
+// renderer.heading = function (text, level) {
+//   var escapedText = text.toLowerCase().replace(/[^\w]+/ig, '-');
+
+//   return '<h' + level + '>' + text + '</h' + level + '>';
+// }
+
+// renderer.threeDollars = function(text) {
+//   return 'Three ' + text + ' Dollars';
+// }
+
+// var lexer = new marked.Lexer({renderer: renderer});
+
+// lexer.rules.threeDollars = /\$\$\$/;
+// if($.inArray('threeDollars', lexer.ruleExecuteOrder) === -1) {
+
+// }
+// console.log(lexer.ruleExecuteOrder.join(','));
+// lexer.ruleFunctions.threeDollars = function(tokenVars, top, bq) {
+//     if (tokenVars.cap = lexer.rules.threeDollars.exec(tokenVars.src)) {
+//       tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
+//       lexer.tokens.push({
+//         type: 'threeDollars',
+//         text: tokenVars.cap
+//       });
+
+//       return true;
+//     }
+
+//     return false;
+// };
+
+// var parser = new marked.Parser({renderer: renderer});
+
+// parser.tok = function() {
+//   switch (this.token.type) {
+//     case 'threeDollars': {
+//       return this.renderer.threeDollars(this.token.text);
+//     }
+//   }
+
+//   return marked.Parser.prototype.tok.apply(this, arguments);
+// };
+
+// console.log(parser.parse(lexer.lex($("#text").val())));
+  	$("#preview").html(marked($("#text").val()));
+  	return;
+    if (x) { x.abort() } // If there is an existing XHR, abort it.
+    clearTimeout(timer); // Clear the timer so we don't end up with dupes.
+    timer = setTimeout(function() { // assign timer a new timeout
+      var startTime = new Date().getTime();
+      parsed = reader.parse($("#text").val());
+      var endTime = new Date().getTime();
+      var parseTime = endTime - startTime;
+      $("#parsetime").text(parseTime);
+      $(".timing").css('visibility','visible');
+      /*
+      var warnings = parsed.warnings;
+      $("#warnings").html('');
+      for (i=0; i < warnings.length; i++) {
+        var w = warnings[i];
+        var warning = $("#warnings").append('<li></li>');
+        $("#warnings li").last().text('Line ' + w.line + ' column ' + w.column + ': ' + w.message);
+      }
+      */
+      render();
+    }, 0); // ms delay
+  };
+  var initial_text = getQueryVariable("text");
+  if (initial_text) {
+    $("#text").val(initial_text);
+    // show HTML tab if text is from query
+    $('#result-tabs a[href="#result"]').tab('show');
+  }
+  // make tab insert a tab in the text box:
+  $("#text").keydown(function (e) {
+    if (e.which == 9) {
+        e.preventDefault();
+        this.value += "\t";
+    }
+  });
+  parseAndRender();
+  $("#clear-text-box").click(function(e) {
+    $("#text").val('');
+    window.location.search = "";
+    parseAndRender();
+  });
+  $("#permalink").click(function(e) {
+    window.location.pathname = "/index.html";
+    window.location.search = "text=" + encodeURIComponent($("#text").val());
+  });
+  $("#text").bind('keyup paste cut mouseup', parseAndRender);
+  $(".option").change(render);
+});
+  </script>
+  <style type="text/css">
+    h1.title { font-family: monospace; font-size: 120%; font-weight: bold;
+          margin-top: 0.5em; margin-bottom: 0; }
+    textarea#text { height: 400px; width: 95%; font-family: monospace; font-size: 92%; }
+    pre code#html { font-size: 92%; font-family: monospace; }
+    pre#htmlpre { height: 400px; overflow: scroll; resize: vertical; width: 95%; }
+    div#astpre  { height: 400px; overflow: scroll; resize: vertical; width: 95%; }
+    div#preview { height: 400px; overflow: scroll; resize: vertical; width: 95%; }
+    div.row { margin-top: 1em; }
+    blockquote { font-size: 100%; }
+    footer { color: #555; text-align: center; margin: 1em; }
+    pre { display: block; padding: 0.5em; color: #333; background: #f8f8ff }
+    #warnings li { color: red; font-weight: bold; }
+    label { padding-left: 1em; padding-top: 0; padding-bottom: 0; }
+    div.timing { color: gray; visibility: hidden; height: 2em; }
+    p#text-controls { height: 1em; margin-top: 1em; }
+    a#permalink { margin-left: 1em; }
+    span.timing { font-weight: bold; }
+    span.timing { font-weight: bold; }
+  </style>
+</head>
+<body>
+<div class="container">
+  <div class="row">
+    <div class="col-md-6">
+      <h1 class="title">commonmark.js dingus</h1>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-6">
+      <p id="text-controls"><a id="clear-text-box">clear</a>&nbsp;<a
+      id="permalink">permalink</a></p>
+      <textarea id="text"></textarea>
+      <ul id="warnings"></ul>
+      <div class="timing">Parsed in <span class="timing" id="parsetime"></span> 
+      ms.  Rendered in <span class="timing" id="rendertime"></span> ms.</div>
+    </div>
+    <div class="col-md-6">
+      <ul id="result-tabs" class="nav nav-tabs" role="tablist">
+        <li class="active"><a href="#preview" role="tab" data-toggle="tab">Preview</a></li>
+        <li><a href="#result" role="tab" data-toggle="tab">HTML</a></li>
+        <li><a href="#result-ast" role="tab" data-toggle="tab">AST</a></li>
+      </ul>
+      <div class="tab-content">
+        <div id="preview" class="tab-pane active">
+        </div>
+        <div id="result" class="tab-pane">
+          <pre id="htmlpre"><code id="html"></code></pre>
+        </div>
+        <div id="result-ast" class="tab-pane">
+          <pre id="astpre"><code id="ast"></code></pre>
+        </div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1377,14 +1377,14 @@ function registerRule(_rule) {
     case 'block': {
       Lexer.prototype.customRules = Lexer.prototype.customRules || {};
       Lexer.prototype.customRules[rule.name] = rule.regExp;
-      Lexer.prototype.ruleExecuteOrderDescending.splice(Lexer.prototype.ruleExecuteOrderDescending.length - rule.positionFromEnd, 0, rule.name);
+      Lexer.prototype.ruleExecuteOrderDescending.splice(rule.positionFromEnd, 0, rule.name);
       Lexer.prototype.ruleFunctions[rule.name] = rule.action;
       break;
     }
     default: {
       InlineLexer.prototype.customRules = InlineLexer.prototype.customRules || {};
       InlineLexer.prototype.customRules[rule.name] = rule.regExp;
-      InlineLexer.prototype.ruleExecuteOrderDescending.splice(InlineLexer.prototype.ruleExecuteOrderDescending.length - rule.positionFromEnd, 0, rule.name);
+      InlineLexer.prototype.ruleExecuteOrderDescending.splice(rule.positionFromEnd, 0, rule.name);
       InlineLexer.prototype.ruleFunctions[rule.name] = rule.action;
     }
   }

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1346,7 +1346,7 @@ function merge(obj) {
 
       // Block rule
       type: 'block',
-      action: function(tokenVars, top, bq) {
+      action: function(tokenVars) {
         if (tokenVars.cap = this.rules.myNewRule.exec(tokenVars.src)) {
           tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
           this.tokens.push({

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -111,6 +111,10 @@ function Lexer(options) {
       this.rules = block.gfm;
     }
   }
+
+  if (this.customRules !== {}) {
+    this.rules = merge(this.rules, this.customRules);
+  }
 }
 
 /**
@@ -118,6 +122,7 @@ function Lexer(options) {
  */
 
 Lexer.rules = block;
+Lexer.prototype.customRules = {};
 
 /**
  * Static Lex Method
@@ -146,199 +151,235 @@ Lexer.prototype.lex = function(src) {
  * Lexing
  */
 
-Lexer.prototype.token = function(src, top, bq) {
-  var src = src.replace(/^ +$/gm, '')
-    , next
-    , loose
-    , cap
-    , bull
-    , b
-    , item
-    , space
-    , i
-    , l;
+Lexer.prototype.ruleExecuteOrder = [
+  'newline',
+  'code',
+  'fences',
+  'heading',
+  'tableNoLeadingPipe',
+  'lheading',
+  'hr',
+  'blockquote',
+  'list',
+  'html',
+  'def',
+  'table',
+  'topLevelParagraph',
+  'text'
+];
 
-  while (src) {
-    // newline
-    if (cap = this.rules.newline.exec(src)) {
-      src = src.substring(cap[0].length);
-      if (cap[0].length > 1) {
+Lexer.prototype.ruleFunctions = {
+  newline: function(tokenVars, top, bq) {
+    if (tokenVars.cap = this.rules.newline.exec(tokenVars.src)) {
+      tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
+      if (tokenVars.cap[0].length > 1) {
         this.tokens.push({
           type: 'space'
         });
       }
     }
 
-    // code
-    if (cap = this.rules.code.exec(src)) {
-      src = src.substring(cap[0].length);
-      cap = cap[0].replace(/^ {4}/gm, '');
+    return false;
+  },
+
+  code: function(tokenVars, top, bq) {
+    if (tokenVars.cap = this.rules.code.exec(tokenVars.src)) {
+      tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
+      tokenVars.cap = tokenVars.cap[0].replace(/^ {4}/gm, '');
       this.tokens.push({
         type: 'code',
         text: !this.options.pedantic
-          ? cap.replace(/\n+$/, '')
-          : cap
+          ? tokenVars.cap.replace(/\n+$/, '')
+          : tokenVars.cap
       });
-      continue;
+
+      return true;
     }
 
-    // fences (gfm)
-    if (cap = this.rules.fences.exec(src)) {
-      src = src.substring(cap[0].length);
+    return false;
+  },
+
+  // fences (gfm)
+  fences: function(tokenVars, top, bq) {
+    if (tokenVars.cap = this.rules.fences.exec(tokenVars.src)) {
+      tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
       this.tokens.push({
         type: 'code',
-        lang: cap[2],
-        text: cap[3]
+        lang: tokenVars.cap[2],
+        text: tokenVars.cap[3]
       });
-      continue;
-    }
 
-    // heading
-    if (cap = this.rules.heading.exec(src)) {
-      src = src.substring(cap[0].length);
+      return true;
+    }
+    
+    return false;
+  },
+  
+  heading: function(tokenVars, top, bq) {
+    if (tokenVars.cap = this.rules.heading.exec(tokenVars.src)) {
+      tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
       this.tokens.push({
         type: 'heading',
-        depth: cap[1].length,
-        text: cap[2]
+        depth: tokenVars.cap[1].length,
+        text: tokenVars.cap[2]
       });
-      continue;
+
+      return true;
     }
+    
+    return false;
+  },
 
-    // table no leading pipe (gfm)
-    if (top && (cap = this.rules.nptable.exec(src))) {
-      src = src.substring(cap[0].length);
+  // table no leading pipe (gfm)
+  tableNoLeadingPipe: function(tokenVars, top, bq) {
+    if (top && (tokenVars.cap = this.rules.nptable.exec(tokenVars.src))) {
+      tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
 
-      item = {
+      tokenVars.item = {
         type: 'table',
-        header: cap[1].replace(/^ *| *\| *$/g, '').split(/ *\| */),
-        align: cap[2].replace(/^ *|\| *$/g, '').split(/ *\| */),
-        cells: cap[3].replace(/\n$/, '').split('\n')
+        header: tokenVars.cap[1].replace(/^ *| *\| *$/g, '').split(/ *\| */),
+        align: tokenVars.cap[2].replace(/^ *|\| *$/g, '').split(/ *\| */),
+        cells: tokenVars.cap[3].replace(/\n$/, '').split('\n')
       };
 
-      for (i = 0; i < item.align.length; i++) {
-        if (/^ *-+: *$/.test(item.align[i])) {
-          item.align[i] = 'right';
-        } else if (/^ *:-+: *$/.test(item.align[i])) {
-          item.align[i] = 'center';
-        } else if (/^ *:-+ *$/.test(item.align[i])) {
-          item.align[i] = 'left';
+      for (i = 0; i < tokenVars.item.align.length; i++) {
+        if (/^ *-+: *$/.test(tokenVars.item.align[i])) {
+          tokenVars.item.align[i] = 'right';
+        } else if (/^ *:-+: *$/.test(tokenVars.item.align[i])) {
+          tokenVars.item.align[i] = 'center';
+        } else if (/^ *:-+ *$/.test(tokenVars.item.align[i])) {
+          tokenVars.item.align[i] = 'left';
         } else {
-          item.align[i] = null;
+          tokenVars.item.align[i] = null;
         }
       }
 
-      for (i = 0; i < item.cells.length; i++) {
-        item.cells[i] = item.cells[i].split(/ *\| */);
+      for (i = 0; i < tokenVars.item.cells.length; i++) {
+        tokenVars.item.cells[i] = tokenVars.item.cells[i].split(/ *\| */);
       }
 
-      this.tokens.push(item);
+      this.tokens.push(tokenVars.item);;
 
-      continue;
+      return true;
     }
+    
+    return false;
+  },
 
-    // lheading
-    if (cap = this.rules.lheading.exec(src)) {
-      src = src.substring(cap[0].length);
+  lheading: function(tokenVars, top, bq) {
+    if (tokenVars.cap = this.rules.lheading.exec(tokenVars.src)) {
+      tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
       this.tokens.push({
         type: 'heading',
-        depth: cap[2] === '=' ? 1 : 2,
-        text: cap[1]
+        depth: tokenVars.cap[2] === '=' ? 1 : 2,
+        text: tokenVars.cap[1]
       });
-      continue;
-    }
 
-    // hr
-    if (cap = this.rules.hr.exec(src)) {
-      src = src.substring(cap[0].length);
+      return true;
+    }
+    
+    return false;
+  },
+
+  hr: function(tokenVars, top, bq) {
+    if (tokenVars.cap = this.rules.hr.exec(tokenVars.src)) {
+      tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
       this.tokens.push({
         type: 'hr'
       });
-      continue;
-    }
 
-    // blockquote
-    if (cap = this.rules.blockquote.exec(src)) {
-      src = src.substring(cap[0].length);
+      return true;
+    }
+    
+    return false;
+  },
+  
+  blockquote: function(tokenVars, top, bq) {
+    if (tokenVars.cap = this.rules.blockquote.exec(tokenVars.src)) {
+      tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
 
       this.tokens.push({
         type: 'blockquote_start'
       });
 
-      cap = cap[0].replace(/^ *> ?/gm, '');
+      tokenVars.cap = tokenVars.cap[0].replace(/^ *> ?/gm, '');
 
       // Pass `top` to keep the current
       // "toplevel" state. This is exactly
       // how markdown.pl works.
-      this.token(cap, top, true);
+      this.token(tokenVars.cap, top, true);
 
       this.tokens.push({
         type: 'blockquote_end'
-      });
+      });;
 
-      continue;
+      return true;
     }
+    
+    return false;
+  },
 
-    // list
-    if (cap = this.rules.list.exec(src)) {
-      src = src.substring(cap[0].length);
-      bull = cap[2];
+  list: function(tokenVars, top, bq) {
+    if (tokenVars.cap = this.rules.list.exec(tokenVars.src)) {
+      tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
+      tokenVars.bull = tokenVars.cap[2];
 
       this.tokens.push({
         type: 'list_start',
-        ordered: bull.length > 1
+        ordered: tokenVars.bull.length > 1
       });
 
-      // Get each top-level item.
-      cap = cap[0].match(this.rules.item);
+      // Get each top-level tokenVars.item.
+      tokenVars.cap = tokenVars.cap[0].match(this.rules.item);
 
-      next = false;
-      l = cap.length;
+      tokenVars.next = false;
+      l = tokenVars.cap.length;
       i = 0;
 
       for (; i < l; i++) {
-        item = cap[i];
+        tokenVars.item = tokenVars.cap[i];
 
-        // Remove the list item's bullet
+        // Remove the list tokenVars.item's tokenVars.bullet
         // so it is seen as the next token.
-        space = item.length;
-        item = item.replace(/^ *([*+-]|\d+\.) +/, '');
+        tokenVars.space = tokenVars.item.length;
+        tokenVars.item = tokenVars.item.replace(/^ *([*+-]|\d+\.) +/, '');
 
         // Outdent whatever the
-        // list item contains. Hacky.
-        if (~item.indexOf('\n ')) {
-          space -= item.length;
-          item = !this.options.pedantic
-            ? item.replace(new RegExp('^ {1,' + space + '}', 'gm'), '')
-            : item.replace(/^ {1,4}/gm, '');
+        // list tokenVars.item contains. Hacky.
+        if (~tokenVars.item.indexOf('\n ')) {
+          tokenVars.space -= tokenVars.item.length;
+          tokenVars.item = !this.options.pedantic
+            ? tokenVars.item.replace(new RegExp('^ {1,' + tokenVars.space + '}', 'gm'), '')
+            : tokenVars.item.replace(/^ {1,4}/gm, '');
         }
 
-        // Determine whether the next list item belongs here.
+        // Determine whether the next list tokenVars.item belongs here.
         // Backpedal if it does not belong in this list.
         if (this.options.smartLists && i !== l - 1) {
-          b = block.bullet.exec(cap[i + 1])[0];
-          if (bull !== b && !(bull.length > 1 && b.length > 1)) {
-            src = cap.slice(i + 1).join('\n') + src;
+          tokenVars.b = block.bullet.exec(tokenVars.cap[i + 1])[0];
+          if (tokenVars.bull !== tokenVars.b && !(tokenVars.bull.length > 1 && tokenVars.b.length > 1)) {
+            tokenVars.src = tokenVars.cap.slice(i + 1).join('\n') + tokenVars.src;
             i = l - 1;
           }
         }
 
-        // Determine whether item is loose or not.
+        // Determine whether tokenVars.item is loose or not.
         // Use: /(^|\n)(?! )[^\n]+\n\n(?!\s*$)/
         // for discount behavior.
-        loose = next || /\n\n(?!\s*$)/.test(item);
+        tokenVars.loose = tokenVars.next || /\n\n(?!\s*$)/.test(tokenVars.item);
         if (i !== l - 1) {
-          next = item.charAt(item.length - 1) === '\n';
-          if (!loose) loose = next;
+          tokenVars.next = tokenVars.item.charAt(tokenVars.item.length - 1) === '\n';
+          if (!tokenVars.loose) tokenVars.loose = tokenVars.next;
         }
 
         this.tokens.push({
-          type: loose
+          type: tokenVars.loose
             ? 'loose_item_start'
             : 'list_item_start'
         });
 
         // Recurse.
-        this.token(item, false, bq);
+        this.token(tokenVars.item, false, bq);
 
         this.tokens.push({
           type: 'list_item_end'
@@ -347,94 +388,149 @@ Lexer.prototype.token = function(src, top, bq) {
 
       this.tokens.push({
         type: 'list_end'
-      });
+      });;
 
-      continue;
+      return true;
     }
+    
+    return false;
+  },
 
-    // html
-    if (cap = this.rules.html.exec(src)) {
-      src = src.substring(cap[0].length);
+  html: function(tokenVars, top, bq) {
+    if (tokenVars.cap = this.rules.html.exec(tokenVars.src)) {
+      tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
       this.tokens.push({
         type: this.options.sanitize
           ? 'paragraph'
           : 'html',
-        pre: cap[1] === 'pre' || cap[1] === 'script' || cap[1] === 'style',
-        text: cap[0]
+        pre: tokenVars.cap[1] === 'pre' || tokenVars.cap[1] === 'script' || tokenVars.cap[1] === 'style',
+        text: tokenVars.cap[0]
       });
-      continue;
-    }
 
-    // def
-    if ((!bq && top) && (cap = this.rules.def.exec(src))) {
-      src = src.substring(cap[0].length);
-      this.tokens.links[cap[1].toLowerCase()] = {
-        href: cap[2],
-        title: cap[3]
+      return true;
+    }
+    
+    return false;
+  },
+
+  def: function(tokenVars, top, bq) {
+    if ((!bq && top) && (tokenVars.cap = this.rules.def.exec(tokenVars.src))) {
+      tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
+      this.tokens.links[tokenVars.cap[1].toLowerCase()] = {
+        href: tokenVars.cap[2],
+        title: tokenVars.cap[3]
       };
-      continue;
+
+      return true;
     }
+    
+    return false;
+  },
 
-    // table (gfm)
-    if (top && (cap = this.rules.table.exec(src))) {
-      src = src.substring(cap[0].length);
+  // table (gfm)
+  table: function(tokenVars, top, bq) {
+    if (top && (tokenVars.cap = this.rules.table.exec(tokenVars.src))) {
+      tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
 
-      item = {
+      tokenVars.item = {
         type: 'table',
-        header: cap[1].replace(/^ *| *\| *$/g, '').split(/ *\| */),
-        align: cap[2].replace(/^ *|\| *$/g, '').split(/ *\| */),
-        cells: cap[3].replace(/(?: *\| *)?\n$/, '').split('\n')
+        header: tokenVars.cap[1].replace(/^ *| *\| *$/g, '').split(/ *\| */),
+        align: tokenVars.cap[2].replace(/^ *|\| *$/g, '').split(/ *\| */),
+        cells: tokenVars.cap[3].replace(/(?: *\| *)?\n$/, '').split('\n')
       };
 
-      for (i = 0; i < item.align.length; i++) {
-        if (/^ *-+: *$/.test(item.align[i])) {
-          item.align[i] = 'right';
-        } else if (/^ *:-+: *$/.test(item.align[i])) {
-          item.align[i] = 'center';
-        } else if (/^ *:-+ *$/.test(item.align[i])) {
-          item.align[i] = 'left';
+      for (i = 0; i < tokenVars.item.align.length; i++) {
+        if (/^ *-+: *$/.test(tokenVars.item.align[i])) {
+          tokenVars.item.align[i] = 'right';
+        } else if (/^ *:-+: *$/.test(tokenVars.item.align[i])) {
+          tokenVars.item.align[i] = 'center';
+        } else if (/^ *:-+ *$/.test(tokenVars.item.align[i])) {
+          tokenVars.item.align[i] = 'left';
         } else {
-          item.align[i] = null;
+          tokenVars.item.align[i] = null;
         }
       }
 
-      for (i = 0; i < item.cells.length; i++) {
-        item.cells[i] = item.cells[i]
+      for (i = 0; i < tokenVars.item.cells.length; i++) {
+        tokenVars.item.cells[i] = tokenVars.item.cells[i]
           .replace(/^ *\| *| *\| *$/g, '')
           .split(/ *\| */);
       }
 
-      this.tokens.push(item);
+      this.tokens.push(tokenVars.item);;
 
-      continue;
+      return true;
     }
+    
+    return false;
+  },
 
-    // top-level paragraph
-    if (top && (cap = this.rules.paragraph.exec(src))) {
-      src = src.substring(cap[0].length);
+  topLevelParagraph: function(tokenVars, top, bq) {
+    if (top && (tokenVars.cap = this.rules.paragraph.exec(tokenVars.src))) {
+      tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
       this.tokens.push({
         type: 'paragraph',
-        text: cap[1].charAt(cap[1].length - 1) === '\n'
-          ? cap[1].slice(0, -1)
-          : cap[1]
+        text: tokenVars.cap[1].charAt(tokenVars.cap[1].length - 1) === '\n'
+          ? tokenVars.cap[1].slice(0, -1)
+          : tokenVars.cap[1]
       });
-      continue;
-    }
 
-    // text
-    if (cap = this.rules.text.exec(src)) {
-      // Top-level should never reach here.
-      src = src.substring(cap[0].length);
+      return true;
+    }
+    
+    return false;
+  },
+
+  text: function(tokenVars, top, bq) {
+    if (tokenVars.cap = this.rules.text.exec(tokenVars.src)) {
+      // top-level should never reach here.
+      tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
       this.tokens.push({
         type: 'text',
-        text: cap[0]
+        text: tokenVars.cap[0]
       });
+
+      return true;
+    }
+    
+    return false;
+  }
+};
+
+Lexer.prototype.token = function(src, top, bq) {
+  var tokenVars = {
+    src: src.replace(/^ +$/gm, ''),
+    next: null,
+    loose: null,
+    cap: null,
+    bull: null,
+    b: null,
+    item: null,
+    space: null,
+    i: null,
+    l: null
+  },
+  skip = false,
+  ruleCount = this.ruleExecuteOrder.length;
+
+  while (tokenVars.src) {
+
+    for (var i = 0; i < ruleCount; i++) {
+      skip = this.ruleFunctions[this.ruleExecuteOrder[i]].call(this, tokenVars, top, bq);
+
+      if (skip === true) {
+        break;
+      }
+    }
+
+    if (skip === true) {
+      skip = false;
       continue;
     }
 
-    if (src) {
+    if (tokenVars.src) {
       throw new
-        Error('Infinite loop on byte: ' + src.charCodeAt(0));
+        Error('Infinite loop on byte: ' + tokenVars.src.charCodeAt(0));
     }
   }
 
@@ -536,6 +632,10 @@ function InlineLexer(links, options) {
   } else if (this.options.pedantic) {
     this.rules = inline.pedantic;
   }
+
+  if (this.customRules !== {}) {
+    this.rules = merge(this.rules, this.customRules);
+  }
 }
 
 /**
@@ -543,6 +643,7 @@ function InlineLexer(links, options) {
  */
 
 InlineLexer.rules = inline;
+InlineLexer.prototype.customRules = {};
 
 /**
  * Static Lexing/Compiling Method
@@ -557,138 +658,222 @@ InlineLexer.output = function(src, links, options) {
  * Lexing/Compiling
  */
 
-InlineLexer.prototype.output = function(src) {
-  var out = ''
-    , link
-    , text
-    , href
-    , cap;
+InlineLexer.prototype.ruleExecuteOrder = [
+  'escape',
+  'autolink',
+  'url',
+  'tag',
+  'link',
+  'reflink',
+  'strong',
+  'em',
+  'code',
+  'br',
+  'del',
+  'text'
+];
 
-  while (src) {
+InlineLexer.prototype.ruleFunctions = {
+  escape: function(outputVars) {
     // escape
-    if (cap = this.rules.escape.exec(src)) {
-      src = src.substring(cap[0].length);
-      out += cap[1];
-      continue;
+    if (outputVars.cap = this.rules.escape.exec(outputVars.src)) {
+      outputVars.src = outputVars.src.substring(outputVars.cap[0].length);
+      outputVars.out += outputVars.cap[1];
+      return true;
     }
 
+    return false;
+  },
+
+  autolink: function(outputVars) {
     // autolink
-    if (cap = this.rules.autolink.exec(src)) {
-      src = src.substring(cap[0].length);
-      if (cap[2] === '@') {
-        text = cap[1].charAt(6) === ':'
-          ? this.mangle(cap[1].substring(7))
-          : this.mangle(cap[1]);
-        href = this.mangle('mailto:') + text;
+    if (outputVars.cap = this.rules.autolink.exec(outputVars.src)) {
+      outputVars.src = outputVars.src.substring(outputVars.cap[0].length);
+      if (outputVars.cap[2] === '@') {
+        outputVars.text = outputVars.cap[1].charAt(6) === ':'
+          ? this.mangle(outputVars.cap[1].substring(7))
+          : this.mangle(outputVars.cap[1]);
+        outputVars.href = this.mangle('mailto:') + text;
       } else {
-        text = escape(cap[1]);
-        href = text;
+        outputVars.text = escape(outputVars.cap[1]);
+        outputVars.href = outputVars.text;
       }
-      out += this.renderer.link(href, null, text);
-      continue;
+      outputVars.out += this.renderer.link(outputVars.href, null, outputVars.text);
+      return true;
     }
 
+    return false;
+  },
+
+  url: function(outputVars) {
     // url (gfm)
-    if (!this.inLink && (cap = this.rules.url.exec(src))) {
-      src = src.substring(cap[0].length);
-      text = escape(cap[1]);
-      href = text;
-      out += this.renderer.link(href, null, text);
-      continue;
+    if (!this.inLink && (outputVars.cap = this.rules.url.exec(outputVars.src))) {
+      outputVars.src = outputVars.src.substring(outputVars.cap[0].length);
+      outputVars.text = escape(outputVars.cap[1]);
+      outputVars.href = outputVars.text;
+      outputVars.out += this.renderer.link(outputVars.href, null, outputVars.text);
+      return true;
     }
 
+    return false;
+  },
+
+  tag: function(outputVars) {
     // tag
-    if (cap = this.rules.tag.exec(src)) {
-      if (!this.inLink && /^<a /i.test(cap[0])) {
+    if (outputVars.cap = this.rules.tag.exec(outputVars.src)) {
+      if (!this.inLink && /^<a /i.test(outputVars.cap[0])) {
         this.inLink = true;
-      } else if (this.inLink && /^<\/a>/i.test(cap[0])) {
+      } else if (this.inLink && /^<\/a>/i.test(outputVars.cap[0])) {
         this.inLink = false;
       }
-      src = src.substring(cap[0].length);
-      out += this.options.sanitize
-        ? escape(cap[0])
-        : cap[0];
-      continue;
+      outputVars.src = outputVars.src.substring(outputVars.cap[0].length);
+      outputVars.out += this.options.sanitize
+        ? escape(outputVars.cap[0])
+        : outputVars.cap[0];
+      return true;
     }
 
+    return false;
+  },
+
+  link: function(outputVars) {
     // link
-    if (cap = this.rules.link.exec(src)) {
-      src = src.substring(cap[0].length);
+    if (outputVars.cap = this.rules.link.exec(outputVars.src)) {
+      outputVars.src = outputVars.src.substring(outputVars.cap[0].length);
       this.inLink = true;
-      out += this.outputLink(cap, {
-        href: cap[2],
-        title: cap[3]
+      outputVars.out += this.outputLink(outputVars.cap, {
+        href: outputVars.cap[2],
+        title: outputVars.cap[3]
       });
       this.inLink = false;
-      continue;
+      return true;
     }
 
+    return false;
+  },
+
+  reflink: function(outputVars) {
     // reflink, nolink
-    if ((cap = this.rules.reflink.exec(src))
-        || (cap = this.rules.nolink.exec(src))) {
-      src = src.substring(cap[0].length);
-      link = (cap[2] || cap[1]).replace(/\s+/g, ' ');
-      link = this.links[link.toLowerCase()];
-      if (!link || !link.href) {
-        out += cap[0].charAt(0);
-        src = cap[0].substring(1) + src;
-        continue;
+    if ((outputVars.cap = this.rules.reflink.exec(outputVars.src))
+        || (outputVars.cap = this.rules.nolink.exec(outputVars.src))) {
+      outputVars.src = outputVars.src.substring(outputVars.cap[0].length);
+      outputVars.link = (outputVars.cap[2] || outputVars.cap[1]).replace(/\s+/g, ' ');
+      outputVars.link = this.links[outputVars.link.toLowerCase()];
+      if (!outputVars.link || !outputVars.link.href) {
+        outputVars.out += outputVars.cap[0].charAt(0);
+        outputVars.src = outputVars.cap[0].substring(1) + outputVars.src;
+        return true;
       }
       this.inLink = true;
-      out += this.outputLink(cap, link);
+      outputVars.out += this.outputLink(outputVars.cap, outputVars.link);
       this.inLink = false;
-      continue;
+      return true;
     }
 
+    return false;
+  },
+
+  strong: function(outputVars) {
     // strong
-    if (cap = this.rules.strong.exec(src)) {
-      src = src.substring(cap[0].length);
-      out += this.renderer.strong(this.output(cap[2] || cap[1]));
-      continue;
+    if (outputVars.cap = this.rules.strong.exec(outputVars.src)) {
+      outputVars.src = outputVars.src.substring(outputVars.cap[0].length);
+      outputVars.out += this.renderer.strong(this.output(outputVars.cap[2] || outputVars.cap[1]));
+      return true;
     }
 
+    return false;
+  },
+
+  em: function(outputVars) {
     // em
-    if (cap = this.rules.em.exec(src)) {
-      src = src.substring(cap[0].length);
-      out += this.renderer.em(this.output(cap[2] || cap[1]));
-      continue;
+    if (outputVars.cap = this.rules.em.exec(outputVars.src)) {
+      outputVars.src = outputVars.src.substring(outputVars.cap[0].length);
+      outputVars.out += this.renderer.em(this.output(outputVars.cap[2] || outputVars.cap[1]));
+      return true;
     }
 
+    return false;
+  },
+
+  code: function(outputVars) {
     // code
-    if (cap = this.rules.code.exec(src)) {
-      src = src.substring(cap[0].length);
-      out += this.renderer.codespan(escape(cap[2], true));
-      continue;
+    if (outputVars.cap = this.rules.code.exec(outputVars.src)) {
+      outputVars.src = outputVars.src.substring(outputVars.cap[0].length);
+      outputVars.out += this.renderer.codespan(escape(outputVars.cap[2], true));
+      return true;
     }
 
+    return false;
+  },
+
+  br: function(outputVars) {
     // br
-    if (cap = this.rules.br.exec(src)) {
-      src = src.substring(cap[0].length);
-      out += this.renderer.br();
-      continue;
+    if (outputVars.cap = this.rules.br.exec(outputVars.src)) {
+      outputVars.src = outputVars.src.substring(outputVars.cap[0].length);
+      outputVars.out += this.renderer.br();
+      return true;
     }
 
+    return false;
+  },
+
+  del: function(outputVars) {
     // del (gfm)
-    if (cap = this.rules.del.exec(src)) {
-      src = src.substring(cap[0].length);
-      out += this.renderer.del(this.output(cap[1]));
-      continue;
+    if (outputVars.cap = this.rules.del.exec(outputVars.src)) {
+      outputVars.src = outputVars.src.substring(outputVars.cap[0].length);
+      outputVars.out += this.renderer.del(this.output(outputVars.cap[1]));
+      return true;
     }
 
+    return false;
+  },
+
+  text: function(outputVars) {
     // text
-    if (cap = this.rules.text.exec(src)) {
-      src = src.substring(cap[0].length);
-      out += escape(this.smartypants(cap[0]));
+    if (outputVars.cap = this.rules.text.exec(outputVars.src)) {
+      outputVars.src = outputVars.src.substring(outputVars.cap[0].length);
+      outputVars.out += escape(this.smartypants(outputVars.cap[0]));
+      return true;
+    }
+
+    return false;
+  }
+};
+
+InlineLexer.prototype.output = function(src) {
+  var outputVars = {
+    src: src,
+    out: '',
+    link: null,
+    text: null,
+    href: null,
+    cap: null
+  },
+  skip = false,
+  ruleCount = this.ruleExecuteOrder.length;
+
+  while (outputVars.src) {
+
+    for (var i = 0; i < ruleCount; i++) {
+      skip = this.ruleFunctions[this.ruleExecuteOrder[i]].call(this, outputVars);
+
+      if (skip === true) {
+        break;
+      }
+    }
+
+    if (skip === true) {
+      skip = false;
       continue;
     }
 
-    if (src) {
+    if (outputVars.src) {
       throw new
-        Error('Infinite loop on byte: ' + src.charCodeAt(0));
+        Error('Infinite loop on byte: ' + outputVars.src.charCodeAt(0));
     }
   }
 
-  return out;
+  return outputVars.out;
 };
 
 /**
@@ -961,112 +1146,114 @@ Parser.prototype.parseText = function() {
  * Parse Current Token
  */
 
-Parser.prototype.tok = function() {
-  switch (this.token.type) {
-    case 'space': {
-      return '';
-    }
-    case 'hr': {
-      return this.renderer.hr();
-    }
-    case 'heading': {
-      return this.renderer.heading(
-        this.inline.output(this.token.text),
-        this.token.depth,
-        this.token.text);
-    }
-    case 'code': {
-      return this.renderer.code(this.token.text,
-        this.token.lang,
-        this.token.escaped);
-    }
-    case 'table': {
-      var header = ''
-        , body = ''
-        , i
-        , row
-        , cell
-        , flags
-        , j;
+Parser.prototype.ruleParserFunctions = {
+  space: function() {
+    return '';
+  },
+  hr: function() {
+    return this.renderer.hr();
+  },
+  heading: function() {
+    return this.renderer.heading(
+      this.inline.output(this.token.text),
+      this.token.depth,
+      this.token.text);
+  },
+  code: function() {
+    return this.renderer.code(this.token.text,
+      this.token.lang,
+      this.token.escaped);
+  },
+  table: function() {
+    var header = ''
+      , body = ''
+      , i
+      , row
+      , cell
+      , flags
+      , j;
 
-      // header
+    // header
+    cell = '';
+    for (i = 0; i < this.token.header.length; i++) {
+      flags = { header: true, align: this.token.align[i] };
+      cell += this.renderer.tablecell(
+        this.inline.output(this.token.header[i]),
+        { header: true, align: this.token.align[i] }
+      );
+    }
+    header += this.renderer.tablerow(cell);
+
+    for (i = 0; i < this.token.cells.length; i++) {
+      row = this.token.cells[i];
+
       cell = '';
-      for (i = 0; i < this.token.header.length; i++) {
-        flags = { header: true, align: this.token.align[i] };
+      for (j = 0; j < row.length; j++) {
         cell += this.renderer.tablecell(
-          this.inline.output(this.token.header[i]),
-          { header: true, align: this.token.align[i] }
+          this.inline.output(row[j]),
+          { header: false, align: this.token.align[j] }
         );
       }
-      header += this.renderer.tablerow(cell);
 
-      for (i = 0; i < this.token.cells.length; i++) {
-        row = this.token.cells[i];
-
-        cell = '';
-        for (j = 0; j < row.length; j++) {
-          cell += this.renderer.tablecell(
-            this.inline.output(row[j]),
-            { header: false, align: this.token.align[j] }
-          );
-        }
-
-        body += this.renderer.tablerow(cell);
-      }
-      return this.renderer.table(header, body);
+      body += this.renderer.tablerow(cell);
     }
-    case 'blockquote_start': {
-      var body = '';
+    return this.renderer.table(header, body);
+  },
+  blockquote_start: function() {
+    var body = '';
 
-      while (this.next().type !== 'blockquote_end') {
-        body += this.tok();
-      }
-
-      return this.renderer.blockquote(body);
+    while (this.next().type !== 'blockquote_end') {
+      body += this.tok();
     }
-    case 'list_start': {
-      var body = ''
-        , ordered = this.token.ordered;
 
-      while (this.next().type !== 'list_end') {
-        body += this.tok();
-      }
+    return this.renderer.blockquote(body);
+  },
+  list_start: function() {
+    var body = ''
+      , ordered = this.token.ordered;
 
-      return this.renderer.list(body, ordered);
+    while (this.next().type !== 'list_end') {
+      body += this.tok();
     }
-    case 'list_item_start': {
-      var body = '';
 
-      while (this.next().type !== 'list_item_end') {
-        body += this.token.type === 'text'
-          ? this.parseText()
-          : this.tok();
-      }
+    return this.renderer.list(body, ordered);
+  },
+  list_item_start: function() {
+    var body = '';
 
-      return this.renderer.listitem(body);
+    while (this.next().type !== 'list_item_end') {
+      body += this.token.type === 'text'
+        ? this.parseText()
+        : this.tok();
     }
-    case 'loose_item_start': {
-      var body = '';
 
-      while (this.next().type !== 'list_item_end') {
-        body += this.tok();
-      }
+    return this.renderer.listitem(body);
+  },
+  loose_item_start: function() {
+    var body = '';
 
-      return this.renderer.listitem(body);
+    while (this.next().type !== 'list_item_end') {
+      body += this.tok();
     }
-    case 'html': {
-      var html = !this.token.pre && !this.options.pedantic
-        ? this.inline.output(this.token.text)
-        : this.token.text;
-      return this.renderer.html(html);
-    }
-    case 'paragraph': {
-      return this.renderer.paragraph(this.inline.output(this.token.text));
-    }
-    case 'text': {
-      return this.renderer.paragraph(this.parseText());
-    }
+
+    return this.renderer.listitem(body);
+  },
+  html: function() {
+    var html = !this.token.pre && !this.options.pedantic
+      ? this.inline.output(this.token.text)
+      : this.token.text;
+    return this.renderer.html(html);
+  },
+  paragraph: function() {
+    return this.renderer.paragraph(this.inline.output(this.token.text));
+  },
+  text: function() {
+    return this.renderer.paragraph(this.parseText());
   }
+};
+
+Parser.prototype.tok = function() {
+  return this.ruleParserFunctions[this.token.type].call(this);
 };
 
 /**
@@ -1127,6 +1314,81 @@ function merge(obj) {
   return obj;
 }
 
+/**
+ * Register a rule
+    var _rule = {
+      // determines the position, starting from the end, when this rule be
+      // evaluated
+      positionFromEnd: 1,
+      regExp: /\$\$\$/,
+      name: 'myNewRule',
+      parser: function() {
+        return this.renderer.myNewRule(this.token.text);
+      },
+      renderer: function(text) {
+        return 'modified ' + text;
+      },
+
+      // Inline rule
+      type: 'inline',
+      action: function(outputVars) {
+        if (outputVars.cap = this.rules.myNewRule.exec(outputVars.src)) {
+          outputVars.src = outputVars.src.substring(outputVars.cap[0].length);
+          outputVars.out += this.renderer.myNewRule(outputVars.cap[0]);
+
+          return true;
+        }
+
+        return false;
+      },
+
+      // Block rule
+      type: 'block',
+      action: function(tokenVars, top, bq) {
+        if (tokenVars.cap = this.rules.myNewRule.exec(tokenVars.src)) {
+          tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
+          this.tokens.push({
+            type: 'myNewRule',
+            text: tokenVars.cap
+          });
+
+          return true;
+        }
+
+        return false;
+      }
+    }
+ */
+function registerRule(_rule) {
+  var ruleDefaults = {
+    positionFromEnd: 1
+  }
+
+  var rule = merge(ruleDefaults, _rule);
+
+  Renderer.prototype[rule.name] = rule.renderer;
+  marked.setOptions({
+    renderer: new Renderer
+  });
+
+  Parser.prototype.ruleParserFunctions[rule.name] = rule.parser;
+
+  switch (rule.type) {
+    case 'block': {
+      Lexer.prototype.customRules = Lexer.prototype.customRules || {};
+      Lexer.prototype.customRules[rule.name] = rule.regExp;
+      Lexer.prototype.ruleExecuteOrder.splice(Lexer.prototype.ruleExecuteOrder.length - rule.positionFromEnd, 0, rule.name);
+      Lexer.prototype.ruleFunctions[rule.name] = rule.action;
+      break;
+    }
+    default: {
+      InlineLexer.prototype.customRules = InlineLexer.prototype.customRules || {};
+      InlineLexer.prototype.customRules[rule.name] = rule.regExp;
+      InlineLexer.prototype.ruleExecuteOrder.splice(InlineLexer.prototype.ruleExecuteOrder.length - rule.positionFromEnd, 0, rule.name);
+      InlineLexer.prototype.ruleFunctions[rule.name] = rule.action;
+    }
+  }
+}
 
 /**
  * Marked
@@ -1258,6 +1520,8 @@ marked.InlineLexer = InlineLexer;
 marked.inlineLexer = InlineLexer.output;
 
 marked.parse = marked;
+
+marked.registerRule = registerRule;
 
 if (typeof module !== 'undefined' && typeof exports === 'object') {
   module.exports = marked;

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -169,7 +169,7 @@ Lexer.prototype.ruleExecuteOrder = [
 ];
 
 Lexer.prototype.ruleFunctions = {
-  newline: function(tokenVars, top, bq) {
+  newline: function(tokenVars) {
     if (tokenVars.cap = this.rules.newline.exec(tokenVars.src)) {
       tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
       if (tokenVars.cap[0].length > 1) {
@@ -182,7 +182,7 @@ Lexer.prototype.ruleFunctions = {
     return false;
   },
 
-  code: function(tokenVars, top, bq) {
+  code: function(tokenVars) {
     if (tokenVars.cap = this.rules.code.exec(tokenVars.src)) {
       tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
       tokenVars.cap = tokenVars.cap[0].replace(/^ {4}/gm, '');
@@ -200,7 +200,7 @@ Lexer.prototype.ruleFunctions = {
   },
 
   // fences (gfm)
-  fences: function(tokenVars, top, bq) {
+  fences: function(tokenVars) {
     if (tokenVars.cap = this.rules.fences.exec(tokenVars.src)) {
       tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
       this.tokens.push({
@@ -215,7 +215,7 @@ Lexer.prototype.ruleFunctions = {
     return false;
   },
   
-  heading: function(tokenVars, top, bq) {
+  heading: function(tokenVars) {
     if (tokenVars.cap = this.rules.heading.exec(tokenVars.src)) {
       tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
       this.tokens.push({
@@ -231,8 +231,8 @@ Lexer.prototype.ruleFunctions = {
   },
 
   // table no leading pipe (gfm)
-  tableNoLeadingPipe: function(tokenVars, top, bq) {
-    if (top && (tokenVars.cap = this.rules.nptable.exec(tokenVars.src))) {
+  tableNoLeadingPipe: function(tokenVars) {
+    if (tokenVars.top && (tokenVars.cap = this.rules.nptable.exec(tokenVars.src))) {
       tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
 
       tokenVars.item = {
@@ -242,23 +242,23 @@ Lexer.prototype.ruleFunctions = {
         cells: tokenVars.cap[3].replace(/\n$/, '').split('\n')
       };
 
-      for (i = 0; i < tokenVars.item.align.length; i++) {
-        if (/^ *-+: *$/.test(tokenVars.item.align[i])) {
-          tokenVars.item.align[i] = 'right';
-        } else if (/^ *:-+: *$/.test(tokenVars.item.align[i])) {
-          tokenVars.item.align[i] = 'center';
-        } else if (/^ *:-+ *$/.test(tokenVars.item.align[i])) {
-          tokenVars.item.align[i] = 'left';
+      for (tokenVars.i = 0; tokenVars.i < tokenVars.item.align.length; tokenVars.i++) {
+        if (/^ *-+: *$/.test(tokenVars.item.align[tokenVars.i])) {
+          tokenVars.item.align[tokenVars.i] = 'right';
+        } else if (/^ *:-+: *$/.test(tokenVars.item.align[tokenVars.i])) {
+          tokenVars.item.align[tokenVars.i] = 'center';
+        } else if (/^ *:-+ *$/.test(tokenVars.item.align[tokenVars.i])) {
+          tokenVars.item.align[tokenVars.i] = 'left';
         } else {
-          tokenVars.item.align[i] = null;
+          tokenVars.item.align[tokenVars.i] = null;
         }
       }
 
-      for (i = 0; i < tokenVars.item.cells.length; i++) {
-        tokenVars.item.cells[i] = tokenVars.item.cells[i].split(/ *\| */);
+      for (tokenVars.i = 0; tokenVars.i < tokenVars.item.cells.length; tokenVars.i++) {
+        tokenVars.item.cells[tokenVars.i] = tokenVars.item.cells[tokenVars.i].split(/ *\| */);
       }
 
-      this.tokens.push(tokenVars.item);;
+      this.tokens.push(tokenVars.item);
 
       return true;
     }
@@ -266,7 +266,7 @@ Lexer.prototype.ruleFunctions = {
     return false;
   },
 
-  lheading: function(tokenVars, top, bq) {
+  lheading: function(tokenVars) {
     if (tokenVars.cap = this.rules.lheading.exec(tokenVars.src)) {
       tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
       this.tokens.push({
@@ -281,7 +281,7 @@ Lexer.prototype.ruleFunctions = {
     return false;
   },
 
-  hr: function(tokenVars, top, bq) {
+  hr: function(tokenVars) {
     if (tokenVars.cap = this.rules.hr.exec(tokenVars.src)) {
       tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
       this.tokens.push({
@@ -294,7 +294,7 @@ Lexer.prototype.ruleFunctions = {
     return false;
   },
   
-  blockquote: function(tokenVars, top, bq) {
+  blockquote: function(tokenVars) {
     if (tokenVars.cap = this.rules.blockquote.exec(tokenVars.src)) {
       tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
 
@@ -307,7 +307,7 @@ Lexer.prototype.ruleFunctions = {
       // Pass `top` to keep the current
       // "toplevel" state. This is exactly
       // how markdown.pl works.
-      this.token(tokenVars.cap, top, true);
+      this.token(tokenVars.cap, tokenVars.top, true);
 
       this.tokens.push({
         type: 'blockquote_end'
@@ -319,7 +319,7 @@ Lexer.prototype.ruleFunctions = {
     return false;
   },
 
-  list: function(tokenVars, top, bq) {
+  list: function(tokenVars) {
     if (tokenVars.cap = this.rules.list.exec(tokenVars.src)) {
       tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
       tokenVars.bull = tokenVars.cap[2];
@@ -333,11 +333,11 @@ Lexer.prototype.ruleFunctions = {
       tokenVars.cap = tokenVars.cap[0].match(this.rules.item);
 
       tokenVars.next = false;
-      l = tokenVars.cap.length;
-      i = 0;
+      tokenVars.l = tokenVars.cap.length;
+      tokenVars.i = 0;
 
-      for (; i < l; i++) {
-        tokenVars.item = tokenVars.cap[i];
+      for (; tokenVars.i < tokenVars.l; tokenVars.i++) {
+        tokenVars.item = tokenVars.cap[tokenVars.i];
 
         // Remove the list tokenVars.item's tokenVars.bullet
         // so it is seen as the next token.
@@ -355,11 +355,11 @@ Lexer.prototype.ruleFunctions = {
 
         // Determine whether the next list tokenVars.item belongs here.
         // Backpedal if it does not belong in this list.
-        if (this.options.smartLists && i !== l - 1) {
-          tokenVars.b = block.bullet.exec(tokenVars.cap[i + 1])[0];
+        if (this.options.smartLists && tokenVars.i !== l - 1) {
+          tokenVars.b = block.bullet.exec(tokenVars.cap[tokenVars.i + 1])[0];
           if (tokenVars.bull !== tokenVars.b && !(tokenVars.bull.length > 1 && tokenVars.b.length > 1)) {
-            tokenVars.src = tokenVars.cap.slice(i + 1).join('\n') + tokenVars.src;
-            i = l - 1;
+            tokenVars.src = tokenVars.cap.slice(tokenVars.i + 1).join('\n') + tokenVars.src;
+            tokenVars.i = tokenVars.l - 1;
           }
         }
 
@@ -367,7 +367,7 @@ Lexer.prototype.ruleFunctions = {
         // Use: /(^|\n)(?! )[^\n]+\n\n(?!\s*$)/
         // for discount behavior.
         tokenVars.loose = tokenVars.next || /\n\n(?!\s*$)/.test(tokenVars.item);
-        if (i !== l - 1) {
+        if (tokenVars.i !== tokenVars.l - 1) {
           tokenVars.next = tokenVars.item.charAt(tokenVars.item.length - 1) === '\n';
           if (!tokenVars.loose) tokenVars.loose = tokenVars.next;
         }
@@ -379,7 +379,7 @@ Lexer.prototype.ruleFunctions = {
         });
 
         // Recurse.
-        this.token(tokenVars.item, false, bq);
+        this.token(tokenVars.item, false, tokenVars.bq);
 
         this.tokens.push({
           type: 'list_item_end'
@@ -396,7 +396,7 @@ Lexer.prototype.ruleFunctions = {
     return false;
   },
 
-  html: function(tokenVars, top, bq) {
+  html: function(tokenVars) {
     if (tokenVars.cap = this.rules.html.exec(tokenVars.src)) {
       tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
       this.tokens.push({
@@ -413,8 +413,8 @@ Lexer.prototype.ruleFunctions = {
     return false;
   },
 
-  def: function(tokenVars, top, bq) {
-    if ((!bq && top) && (tokenVars.cap = this.rules.def.exec(tokenVars.src))) {
+  def: function(tokenVars) {
+    if ((!tokenVars.bq && tokenVars.top) && (tokenVars.cap = this.rules.def.exec(tokenVars.src))) {
       tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
       this.tokens.links[tokenVars.cap[1].toLowerCase()] = {
         href: tokenVars.cap[2],
@@ -428,8 +428,8 @@ Lexer.prototype.ruleFunctions = {
   },
 
   // table (gfm)
-  table: function(tokenVars, top, bq) {
-    if (top && (tokenVars.cap = this.rules.table.exec(tokenVars.src))) {
+  table: function(tokenVars) {
+    if (tokenVars.top && (tokenVars.cap = this.rules.table.exec(tokenVars.src))) {
       tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
 
       tokenVars.item = {
@@ -439,20 +439,20 @@ Lexer.prototype.ruleFunctions = {
         cells: tokenVars.cap[3].replace(/(?: *\| *)?\n$/, '').split('\n')
       };
 
-      for (i = 0; i < tokenVars.item.align.length; i++) {
-        if (/^ *-+: *$/.test(tokenVars.item.align[i])) {
-          tokenVars.item.align[i] = 'right';
-        } else if (/^ *:-+: *$/.test(tokenVars.item.align[i])) {
-          tokenVars.item.align[i] = 'center';
-        } else if (/^ *:-+ *$/.test(tokenVars.item.align[i])) {
-          tokenVars.item.align[i] = 'left';
+      for (tokenVars.i = 0; tokenVars.i < tokenVars.item.align.length; tokenVars.i++) {
+        if (/^ *-+: *$/.test(tokenVars.item.align[tokenVars.i])) {
+          tokenVars.item.align[tokenVars.i] = 'right';
+        } else if (/^ *:-+: *$/.test(tokenVars.item.align[tokenVars.i])) {
+          tokenVars.item.align[tokenVars.i] = 'center';
+        } else if (/^ *:-+ *$/.test(tokenVars.item.align[tokenVars.i])) {
+          tokenVars.item.align[tokenVars.i] = 'left';
         } else {
-          tokenVars.item.align[i] = null;
+          tokenVars.item.align[tokenVars.i] = null;
         }
       }
 
-      for (i = 0; i < tokenVars.item.cells.length; i++) {
-        tokenVars.item.cells[i] = tokenVars.item.cells[i]
+      for (tokenVars.i = 0; tokenVars.i < tokenVars.item.cells.length; tokenVars.i++) {
+        tokenVars.item.cells[tokenVars.i] = tokenVars.item.cells[tokenVars.i]
           .replace(/^ *\| *| *\| *$/g, '')
           .split(/ *\| */);
       }
@@ -465,8 +465,8 @@ Lexer.prototype.ruleFunctions = {
     return false;
   },
 
-  topLevelParagraph: function(tokenVars, top, bq) {
-    if (top && (tokenVars.cap = this.rules.paragraph.exec(tokenVars.src))) {
+  topLevelParagraph: function(tokenVars) {
+    if (tokenVars.top && (tokenVars.cap = this.rules.paragraph.exec(tokenVars.src))) {
       tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
       this.tokens.push({
         type: 'paragraph',
@@ -481,7 +481,7 @@ Lexer.prototype.ruleFunctions = {
     return false;
   },
 
-  text: function(tokenVars, top, bq) {
+  text: function(tokenVars) {
     if (tokenVars.cap = this.rules.text.exec(tokenVars.src)) {
       // top-level should never reach here.
       tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
@@ -499,7 +499,7 @@ Lexer.prototype.ruleFunctions = {
 
 Lexer.prototype.token = function(src, top, bq) {
   var tokenVars = {
-    src: src.replace(/^ +$/gm, ''),
+    'src': src.replace(/^ +$/gm, ''),
     next: null,
     loose: null,
     cap: null,
@@ -508,7 +508,9 @@ Lexer.prototype.token = function(src, top, bq) {
     item: null,
     space: null,
     i: null,
-    l: null
+    l: null,
+    'top': top,
+    'bq': bq
   },
   skip = false,
   ruleCount = this.ruleExecuteOrder.length;
@@ -516,7 +518,7 @@ Lexer.prototype.token = function(src, top, bq) {
   while (tokenVars.src) {
 
     for (var i = 0; i < ruleCount; i++) {
-      skip = this.ruleFunctions[this.ruleExecuteOrder[i]].call(this, tokenVars, top, bq);
+      skip = this.ruleFunctions[this.ruleExecuteOrder[i]].call(this, tokenVars);
 
       if (skip === true) {
         break;

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1,8 +1,8 @@
 /**
- * marked - a markdown parser
- * Copyright (c) 2011-2014, Christopher Jeffrey. (MIT Licensed)
- * https://github.com/chjj/marked
- */
+  * marked - a markdown parser
+  * Copyright (c) 2011-2014, Christopher Jeffrey. (MIT Licensed)
+  * https://github.com/chjj/marked
+  */
 
 ;(function() {
 
@@ -151,29 +151,29 @@ Lexer.prototype.lex = function(src) {
  * Lexing
  */
 
-Lexer.prototype.ruleExecuteOrder = [
-  'newline',
-  'code',
-  'fences',
-  'heading',
-  'tableNoLeadingPipe',
-  'lheading',
-  'hr',
-  'blockquote',
-  'list',
-  'html',
-  'def',
-  'table',
-  'topLevelParagraph',
-  'text'
+Lexer.prototype.ruleExecuteOrderDescending = [
+  "text",
+  "topLevelParagraph",
+  "table",
+  "def",
+  "html",
+  "list",
+  "blockquote",
+  "hr",
+  "lheading",
+  "tableNoLeadingPipe",
+  "heading",
+  "fences",
+  "code",
+  "newline"
 ];
 
 Lexer.prototype.ruleFunctions = {
-  newline: function(tokenVars) {
-    if (tokenVars.cap = this.rules.newline.exec(tokenVars.src)) {
+  newline: function(that, tokenVars) {
+    if (tokenVars.cap = that.rules.newline.exec(tokenVars.src)) {
       tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
       if (tokenVars.cap[0].length > 1) {
-        this.tokens.push({
+        that.tokens.push({
           type: 'space'
         });
       }
@@ -182,13 +182,13 @@ Lexer.prototype.ruleFunctions = {
     return false;
   },
 
-  code: function(tokenVars) {
-    if (tokenVars.cap = this.rules.code.exec(tokenVars.src)) {
+  code: function(that, tokenVars) {
+    if (tokenVars.cap = that.rules.code.exec(tokenVars.src)) {
       tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
       tokenVars.cap = tokenVars.cap[0].replace(/^ {4}/gm, '');
-      this.tokens.push({
+      that.tokens.push({
         type: 'code',
-        text: !this.options.pedantic
+        text: !that.options.pedantic
           ? tokenVars.cap.replace(/\n+$/, '')
           : tokenVars.cap
       });
@@ -200,10 +200,10 @@ Lexer.prototype.ruleFunctions = {
   },
 
   // fences (gfm)
-  fences: function(tokenVars) {
-    if (tokenVars.cap = this.rules.fences.exec(tokenVars.src)) {
+  fences: function(that, tokenVars) {
+    if (tokenVars.cap = that.rules.fences.exec(tokenVars.src)) {
       tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
-      this.tokens.push({
+      that.tokens.push({
         type: 'code',
         lang: tokenVars.cap[2],
         text: tokenVars.cap[3]
@@ -211,14 +211,14 @@ Lexer.prototype.ruleFunctions = {
 
       return true;
     }
-    
+
     return false;
   },
-  
-  heading: function(tokenVars) {
-    if (tokenVars.cap = this.rules.heading.exec(tokenVars.src)) {
+
+  heading: function(that, tokenVars) {
+    if (tokenVars.cap = that.rules.heading.exec(tokenVars.src)) {
       tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
-      this.tokens.push({
+      that.tokens.push({
         type: 'heading',
         depth: tokenVars.cap[1].length,
         text: tokenVars.cap[2]
@@ -226,13 +226,13 @@ Lexer.prototype.ruleFunctions = {
 
       return true;
     }
-    
+
     return false;
   },
 
   // table no leading pipe (gfm)
-  tableNoLeadingPipe: function(tokenVars) {
-    if (tokenVars.top && (tokenVars.cap = this.rules.nptable.exec(tokenVars.src))) {
+  tableNoLeadingPipe: function(that, tokenVars) {
+    if (tokenVars.top && (tokenVars.cap = that.rules.nptable.exec(tokenVars.src))) {
       tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
 
       tokenVars.item = {
@@ -258,18 +258,18 @@ Lexer.prototype.ruleFunctions = {
         tokenVars.item.cells[tokenVars.i] = tokenVars.item.cells[tokenVars.i].split(/ *\| */);
       }
 
-      this.tokens.push(tokenVars.item);
+      that.tokens.push(tokenVars.item);
 
       return true;
     }
-    
+
     return false;
   },
 
-  lheading: function(tokenVars) {
-    if (tokenVars.cap = this.rules.lheading.exec(tokenVars.src)) {
+  lheading: function(that, tokenVars) {
+    if (tokenVars.cap = that.rules.lheading.exec(tokenVars.src)) {
       tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
-      this.tokens.push({
+      that.tokens.push({
         type: 'heading',
         depth: tokenVars.cap[2] === '=' ? 1 : 2,
         text: tokenVars.cap[1]
@@ -277,60 +277,60 @@ Lexer.prototype.ruleFunctions = {
 
       return true;
     }
-    
+
     return false;
   },
 
-  hr: function(tokenVars) {
-    if (tokenVars.cap = this.rules.hr.exec(tokenVars.src)) {
+  hr: function(that, tokenVars) {
+    if (tokenVars.cap = that.rules.hr.exec(tokenVars.src)) {
       tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
-      this.tokens.push({
+      that.tokens.push({
         type: 'hr'
       });
 
       return true;
     }
-    
+
     return false;
   },
-  
-  blockquote: function(tokenVars) {
-    if (tokenVars.cap = this.rules.blockquote.exec(tokenVars.src)) {
+
+  blockquote: function(that, tokenVars) {
+    if (tokenVars.cap = that.rules.blockquote.exec(tokenVars.src)) {
       tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
 
-      this.tokens.push({
+      that.tokens.push({
         type: 'blockquote_start'
       });
 
       tokenVars.cap = tokenVars.cap[0].replace(/^ *> ?/gm, '');
 
       // Pass `top` to keep the current
-      // "toplevel" state. This is exactly
+      // "toplevel" state. that is exactly
       // how markdown.pl works.
-      this.token(tokenVars.cap, tokenVars.top, true);
+      that.token(tokenVars.cap, tokenVars.top, true);
 
-      this.tokens.push({
+      that.tokens.push({
         type: 'blockquote_end'
-      });;
+      });
 
       return true;
     }
-    
+
     return false;
   },
 
-  list: function(tokenVars) {
-    if (tokenVars.cap = this.rules.list.exec(tokenVars.src)) {
+  list: function(that, tokenVars) {
+    if (tokenVars.cap = that.rules.list.exec(tokenVars.src)) {
       tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
       tokenVars.bull = tokenVars.cap[2];
 
-      this.tokens.push({
+      that.tokens.push({
         type: 'list_start',
         ordered: tokenVars.bull.length > 1
       });
 
       // Get each top-level tokenVars.item.
-      tokenVars.cap = tokenVars.cap[0].match(this.rules.item);
+      tokenVars.cap = tokenVars.cap[0].match(that.rules.item);
 
       tokenVars.next = false;
       tokenVars.l = tokenVars.cap.length;
@@ -348,14 +348,14 @@ Lexer.prototype.ruleFunctions = {
         // list tokenVars.item contains. Hacky.
         if (~tokenVars.item.indexOf('\n ')) {
           tokenVars.space -= tokenVars.item.length;
-          tokenVars.item = !this.options.pedantic
+          tokenVars.item = !that.options.pedantic
             ? tokenVars.item.replace(new RegExp('^ {1,' + tokenVars.space + '}', 'gm'), '')
             : tokenVars.item.replace(/^ {1,4}/gm, '');
         }
 
         // Determine whether the next list tokenVars.item belongs here.
-        // Backpedal if it does not belong in this list.
-        if (this.options.smartLists && tokenVars.i !== l - 1) {
+        // Backpedal if it does not belong in that list.
+        if (that.options.smartLists && tokenVars.i !== l - 1) {
           tokenVars.b = block.bullet.exec(tokenVars.cap[tokenVars.i + 1])[0];
           if (tokenVars.bull !== tokenVars.b && !(tokenVars.bull.length > 1 && tokenVars.b.length > 1)) {
             tokenVars.src = tokenVars.cap.slice(tokenVars.i + 1).join('\n') + tokenVars.src;
@@ -372,35 +372,35 @@ Lexer.prototype.ruleFunctions = {
           if (!tokenVars.loose) tokenVars.loose = tokenVars.next;
         }
 
-        this.tokens.push({
+        that.tokens.push({
           type: tokenVars.loose
             ? 'loose_item_start'
             : 'list_item_start'
         });
 
         // Recurse.
-        this.token(tokenVars.item, false, tokenVars.bq);
+        that.token(tokenVars.item, false, tokenVars.bq);
 
-        this.tokens.push({
+        that.tokens.push({
           type: 'list_item_end'
         });
       }
 
-      this.tokens.push({
+      that.tokens.push({
         type: 'list_end'
-      });;
+      });
 
       return true;
     }
-    
+
     return false;
   },
 
-  html: function(tokenVars) {
-    if (tokenVars.cap = this.rules.html.exec(tokenVars.src)) {
+  html: function(that, tokenVars) {
+    if (tokenVars.cap = that.rules.html.exec(tokenVars.src)) {
       tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
-      this.tokens.push({
-        type: this.options.sanitize
+      that.tokens.push({
+        type: that.options.sanitize
           ? 'paragraph'
           : 'html',
         pre: tokenVars.cap[1] === 'pre' || tokenVars.cap[1] === 'script' || tokenVars.cap[1] === 'style',
@@ -409,27 +409,27 @@ Lexer.prototype.ruleFunctions = {
 
       return true;
     }
-    
+
     return false;
   },
 
-  def: function(tokenVars) {
-    if ((!tokenVars.bq && tokenVars.top) && (tokenVars.cap = this.rules.def.exec(tokenVars.src))) {
+  def: function(that, tokenVars) {
+    if ((!tokenVars.bq && tokenVars.top) && (tokenVars.cap = that.rules.def.exec(tokenVars.src))) {
       tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
-      this.tokens.links[tokenVars.cap[1].toLowerCase()] = {
+      that.tokens.links[tokenVars.cap[1].toLowerCase()] = {
         href: tokenVars.cap[2],
         title: tokenVars.cap[3]
       };
 
       return true;
     }
-    
+
     return false;
   },
 
   // table (gfm)
-  table: function(tokenVars) {
-    if (tokenVars.top && (tokenVars.cap = this.rules.table.exec(tokenVars.src))) {
+  table: function(that, tokenVars) {
+    if (tokenVars.top && (tokenVars.cap = that.rules.table.exec(tokenVars.src))) {
       tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
 
       tokenVars.item = {
@@ -457,18 +457,18 @@ Lexer.prototype.ruleFunctions = {
           .split(/ *\| */);
       }
 
-      this.tokens.push(tokenVars.item);;
+      that.tokens.push(tokenVars.item);
 
       return true;
     }
-    
+
     return false;
   },
 
-  topLevelParagraph: function(tokenVars) {
-    if (tokenVars.top && (tokenVars.cap = this.rules.paragraph.exec(tokenVars.src))) {
+  topLevelParagraph: function(that, tokenVars) {
+    if (tokenVars.top && (tokenVars.cap = that.rules.paragraph.exec(tokenVars.src))) {
       tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
-      this.tokens.push({
+      that.tokens.push({
         type: 'paragraph',
         text: tokenVars.cap[1].charAt(tokenVars.cap[1].length - 1) === '\n'
           ? tokenVars.cap[1].slice(0, -1)
@@ -477,22 +477,22 @@ Lexer.prototype.ruleFunctions = {
 
       return true;
     }
-    
+
     return false;
   },
 
-  text: function(tokenVars) {
-    if (tokenVars.cap = this.rules.text.exec(tokenVars.src)) {
+  text: function(that, tokenVars) {
+    if (tokenVars.cap = that.rules.text.exec(tokenVars.src)) {
       // top-level should never reach here.
       tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
-      this.tokens.push({
+      that.tokens.push({
         type: 'text',
         text: tokenVars.cap[0]
       });
 
       return true;
     }
-    
+
     return false;
   }
 };
@@ -512,13 +512,12 @@ Lexer.prototype.token = function(src, top, bq) {
     'top': top,
     'bq': bq
   },
-  skip = false,
-  ruleCount = this.ruleExecuteOrder.length;
+  skip = false;
 
   while (tokenVars.src) {
 
-    for (var i = 0; i < ruleCount; i++) {
-      skip = this.ruleFunctions[this.ruleExecuteOrder[i]].call(this, tokenVars);
+    for (var i = this.ruleExecuteOrderDescending.length; i--;) {
+      skip = this.ruleFunctions[this.ruleExecuteOrderDescending[i]](this, tokenVars);
 
       if (skip === true) {
         break;
@@ -660,25 +659,25 @@ InlineLexer.output = function(src, links, options) {
  * Lexing/Compiling
  */
 
-InlineLexer.prototype.ruleExecuteOrder = [
-  'escape',
-  'autolink',
-  'url',
-  'tag',
-  'link',
-  'reflink',
-  'strong',
-  'em',
-  'code',
-  'br',
-  'del',
-  'text'
+InlineLexer.prototype.ruleExecuteOrderDescending = [
+  "text",
+  "del",
+  "br",
+  "code",
+  "em",
+  "strong",
+  "reflink",
+  "link",
+  "tag",
+  "url",
+  "autolink",
+  "escape"
 ];
 
 InlineLexer.prototype.ruleFunctions = {
-  escape: function(outputVars) {
+  escape: function(that, outputVars) {
     // escape
-    if (outputVars.cap = this.rules.escape.exec(outputVars.src)) {
+    if (outputVars.cap = that.rules.escape.exec(outputVars.src)) {
       outputVars.src = outputVars.src.substring(outputVars.cap[0].length);
       outputVars.out += outputVars.cap[1];
       return true;
@@ -687,49 +686,49 @@ InlineLexer.prototype.ruleFunctions = {
     return false;
   },
 
-  autolink: function(outputVars) {
+  autolink: function(that, outputVars) {
     // autolink
-    if (outputVars.cap = this.rules.autolink.exec(outputVars.src)) {
+    if (outputVars.cap = that.rules.autolink.exec(outputVars.src)) {
       outputVars.src = outputVars.src.substring(outputVars.cap[0].length);
       if (outputVars.cap[2] === '@') {
         outputVars.text = outputVars.cap[1].charAt(6) === ':'
-          ? this.mangle(outputVars.cap[1].substring(7))
-          : this.mangle(outputVars.cap[1]);
-        outputVars.href = this.mangle('mailto:') + text;
+          ? that.mangle(outputVars.cap[1].substring(7))
+          : that.mangle(outputVars.cap[1]);
+        outputVars.href = that.mangle('mailto:') + text;
       } else {
         outputVars.text = escape(outputVars.cap[1]);
         outputVars.href = outputVars.text;
       }
-      outputVars.out += this.renderer.link(outputVars.href, null, outputVars.text);
+      outputVars.out += that.renderer.link(outputVars.href, null, outputVars.text);
       return true;
     }
 
     return false;
   },
 
-  url: function(outputVars) {
+  url: function(that, outputVars) {
     // url (gfm)
-    if (!this.inLink && (outputVars.cap = this.rules.url.exec(outputVars.src))) {
+    if (!that.inLink && (outputVars.cap = that.rules.url.exec(outputVars.src))) {
       outputVars.src = outputVars.src.substring(outputVars.cap[0].length);
       outputVars.text = escape(outputVars.cap[1]);
       outputVars.href = outputVars.text;
-      outputVars.out += this.renderer.link(outputVars.href, null, outputVars.text);
+      outputVars.out += that.renderer.link(outputVars.href, null, outputVars.text);
       return true;
     }
 
     return false;
   },
 
-  tag: function(outputVars) {
+  tag: function(that, outputVars) {
     // tag
-    if (outputVars.cap = this.rules.tag.exec(outputVars.src)) {
-      if (!this.inLink && /^<a /i.test(outputVars.cap[0])) {
-        this.inLink = true;
-      } else if (this.inLink && /^<\/a>/i.test(outputVars.cap[0])) {
-        this.inLink = false;
+    if (outputVars.cap = that.rules.tag.exec(outputVars.src)) {
+      if (!that.inLink && /^<a /i.test(outputVars.cap[0])) {
+        that.inLink = true;
+      } else if (that.inLink && /^<\/a>/i.test(outputVars.cap[0])) {
+        that.inLink = false;
       }
       outputVars.src = outputVars.src.substring(outputVars.cap[0].length);
-      outputVars.out += this.options.sanitize
+      outputVars.out += that.options.sanitize
         ? escape(outputVars.cap[0])
         : outputVars.cap[0];
       return true;
@@ -738,103 +737,103 @@ InlineLexer.prototype.ruleFunctions = {
     return false;
   },
 
-  link: function(outputVars) {
+  link: function(that, outputVars) {
     // link
-    if (outputVars.cap = this.rules.link.exec(outputVars.src)) {
+    if (outputVars.cap = that.rules.link.exec(outputVars.src)) {
       outputVars.src = outputVars.src.substring(outputVars.cap[0].length);
-      this.inLink = true;
-      outputVars.out += this.outputLink(outputVars.cap, {
+      that.inLink = true;
+      outputVars.out += that.outputLink(outputVars.cap, {
         href: outputVars.cap[2],
         title: outputVars.cap[3]
       });
-      this.inLink = false;
+      that.inLink = false;
       return true;
     }
 
     return false;
   },
 
-  reflink: function(outputVars) {
+  reflink: function(that, outputVars) {
     // reflink, nolink
-    if ((outputVars.cap = this.rules.reflink.exec(outputVars.src))
-        || (outputVars.cap = this.rules.nolink.exec(outputVars.src))) {
+    if ((outputVars.cap = that.rules.reflink.exec(outputVars.src))
+      || (outputVars.cap = that.rules.nolink.exec(outputVars.src))) {
       outputVars.src = outputVars.src.substring(outputVars.cap[0].length);
       outputVars.link = (outputVars.cap[2] || outputVars.cap[1]).replace(/\s+/g, ' ');
-      outputVars.link = this.links[outputVars.link.toLowerCase()];
+      outputVars.link = that.links[outputVars.link.toLowerCase()];
       if (!outputVars.link || !outputVars.link.href) {
         outputVars.out += outputVars.cap[0].charAt(0);
         outputVars.src = outputVars.cap[0].substring(1) + outputVars.src;
         return true;
       }
-      this.inLink = true;
-      outputVars.out += this.outputLink(outputVars.cap, outputVars.link);
-      this.inLink = false;
+      that.inLink = true;
+      outputVars.out += that.outputLink(outputVars.cap, outputVars.link);
+      that.inLink = false;
       return true;
     }
 
     return false;
   },
 
-  strong: function(outputVars) {
+  strong: function(that, outputVars) {
     // strong
-    if (outputVars.cap = this.rules.strong.exec(outputVars.src)) {
+    if (outputVars.cap = that.rules.strong.exec(outputVars.src)) {
       outputVars.src = outputVars.src.substring(outputVars.cap[0].length);
-      outputVars.out += this.renderer.strong(this.output(outputVars.cap[2] || outputVars.cap[1]));
+      outputVars.out += that.renderer.strong(that.output(outputVars.cap[2] || outputVars.cap[1]));
       return true;
     }
 
     return false;
   },
 
-  em: function(outputVars) {
+  em: function(that, outputVars) {
     // em
-    if (outputVars.cap = this.rules.em.exec(outputVars.src)) {
+    if (outputVars.cap = that.rules.em.exec(outputVars.src)) {
       outputVars.src = outputVars.src.substring(outputVars.cap[0].length);
-      outputVars.out += this.renderer.em(this.output(outputVars.cap[2] || outputVars.cap[1]));
+      outputVars.out += that.renderer.em(that.output(outputVars.cap[2] || outputVars.cap[1]));
       return true;
     }
 
     return false;
   },
 
-  code: function(outputVars) {
+  code: function(that, outputVars) {
     // code
-    if (outputVars.cap = this.rules.code.exec(outputVars.src)) {
+    if (outputVars.cap = that.rules.code.exec(outputVars.src)) {
       outputVars.src = outputVars.src.substring(outputVars.cap[0].length);
-      outputVars.out += this.renderer.codespan(escape(outputVars.cap[2], true));
+      outputVars.out += that.renderer.codespan(escape(outputVars.cap[2], true));
       return true;
     }
 
     return false;
   },
 
-  br: function(outputVars) {
+  br: function(that, outputVars) {
     // br
-    if (outputVars.cap = this.rules.br.exec(outputVars.src)) {
+    if (outputVars.cap = that.rules.br.exec(outputVars.src)) {
       outputVars.src = outputVars.src.substring(outputVars.cap[0].length);
-      outputVars.out += this.renderer.br();
+      outputVars.out += that.renderer.br();
       return true;
     }
 
     return false;
   },
 
-  del: function(outputVars) {
+  del: function(that, outputVars) {
     // del (gfm)
-    if (outputVars.cap = this.rules.del.exec(outputVars.src)) {
+    if (outputVars.cap = that.rules.del.exec(outputVars.src)) {
       outputVars.src = outputVars.src.substring(outputVars.cap[0].length);
-      outputVars.out += this.renderer.del(this.output(outputVars.cap[1]));
+      outputVars.out += that.renderer.del(that.output(outputVars.cap[1]));
       return true;
     }
 
     return false;
   },
 
-  text: function(outputVars) {
+  text: function(that, outputVars) {
     // text
-    if (outputVars.cap = this.rules.text.exec(outputVars.src)) {
+    if (outputVars.cap = that.rules.text.exec(outputVars.src)) {
       outputVars.src = outputVars.src.substring(outputVars.cap[0].length);
-      outputVars.out += escape(this.smartypants(outputVars.cap[0]));
+      outputVars.out += escape(that.smartypants(outputVars.cap[0]));
       return true;
     }
 
@@ -851,13 +850,12 @@ InlineLexer.prototype.output = function(src) {
     href: null,
     cap: null
   },
-  skip = false,
-  ruleCount = this.ruleExecuteOrder.length;
+  skip = false;
 
   while (outputVars.src) {
 
-    for (var i = 0; i < ruleCount; i++) {
-      skip = this.ruleFunctions[this.ruleExecuteOrder[i]].call(this, outputVars);
+    for (var i = this.ruleExecuteOrderDescending.length; i--;) {
+      skip = this.ruleFunctions[this.ruleExecuteOrderDescending[i]](this, outputVars);
 
       if (skip === true) {
         break;
@@ -1333,10 +1331,10 @@ function merge(obj) {
 
       // Inline rule
       type: 'inline',
-      action: function(outputVars) {
-        if (outputVars.cap = this.rules.myNewRule.exec(outputVars.src)) {
+      action: function(that, outputVars) {
+        if (outputVars.cap = that.rules.myNewRule.exec(outputVars.src)) {
           outputVars.src = outputVars.src.substring(outputVars.cap[0].length);
-          outputVars.out += this.renderer.myNewRule(outputVars.cap[0]);
+          outputVars.out += that.renderer.myNewRule(outputVars.cap[0]);
 
           return true;
         }
@@ -1346,10 +1344,10 @@ function merge(obj) {
 
       // Block rule
       type: 'block',
-      action: function(tokenVars) {
-        if (tokenVars.cap = this.rules.myNewRule.exec(tokenVars.src)) {
+      action: function(that, tokenVars) {
+        if (tokenVars.cap = that.rules.myNewRule.exec(tokenVars.src)) {
           tokenVars.src = tokenVars.src.substring(tokenVars.cap[0].length);
-          this.tokens.push({
+          that.tokens.push({
             type: 'myNewRule',
             text: tokenVars.cap
           });
@@ -1379,14 +1377,14 @@ function registerRule(_rule) {
     case 'block': {
       Lexer.prototype.customRules = Lexer.prototype.customRules || {};
       Lexer.prototype.customRules[rule.name] = rule.regExp;
-      Lexer.prototype.ruleExecuteOrder.splice(Lexer.prototype.ruleExecuteOrder.length - rule.positionFromEnd, 0, rule.name);
+      Lexer.prototype.ruleExecuteOrderDescending.splice(Lexer.prototype.ruleExecuteOrderDescending.length - rule.positionFromEnd, 0, rule.name);
       Lexer.prototype.ruleFunctions[rule.name] = rule.action;
       break;
     }
     default: {
       InlineLexer.prototype.customRules = InlineLexer.prototype.customRules || {};
       InlineLexer.prototype.customRules[rule.name] = rule.regExp;
-      InlineLexer.prototype.ruleExecuteOrder.splice(InlineLexer.prototype.ruleExecuteOrder.length - rule.positionFromEnd, 0, rule.name);
+      InlineLexer.prototype.ruleExecuteOrderDescending.splice(InlineLexer.prototype.ruleExecuteOrderDescending.length - rule.positionFromEnd, 0, rule.name);
       InlineLexer.prototype.ruleFunctions[rule.name] = rule.action;
     }
   }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "devDependencies": {
     "markdown": "*",
     "showdown": "*",
-    "robotskirt": "*"
+    "robotskirt": "*",
+    "remarkable": "*"
   },
   "scripts": { "test": "node test", "bench": "node test --bench" }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -297,6 +297,21 @@ function runBench(options) {
   } catch (e) {
     console.log('Could not bench markdown.js.');
   }
+
+  // remarkable
+  try {
+    var Remarkable = require('remarkable');
+    var md = new Remarkable({
+      html: true,
+      linkify: true,
+      typographer: true
+    });
+    bench('remarkable', function(data) {
+      return md.render(data);
+    });
+  } catch (e) {
+    console.log('Could not bench remarkable.');
+  }
 }
 
 /**


### PR DESCRIPTION
I've gone through a process to allow for the addition of new unique rules to **marked**. A new rule can be added easily enough by passing a properly formatted POJO to registerRule. The downside of this addition is a increased parse time, by 32.6%, when running the included bench test. The original project was focused on speed, and I wonder if this is enough deviation to be a full fork and not be pulled in.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/chjj/marked/513)
<!-- Reviewable:end -->
