### PR TITLE
Generate unique ids for headers with duplicate text

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -148,6 +148,7 @@ Lexer.prototype.lex = function(src) {
 
 Lexer.prototype.token = function(src, top, bq) {
   var src = src.replace(/^ +$/gm, '')
+    , links = {}
     , next
     , loose
     , cap
@@ -157,6 +158,24 @@ Lexer.prototype.token = function(src, top, bq) {
     , space
     , i
     , l;
+
+  function uniqueAnchor(text){
+    var rawAnchor = text.toLowerCase().replace(/[^\w]+/g, '-');
+    var anchor = rawAnchor;
+
+    if(!links[anchor]){
+        links[anchor] = anchor;
+        return anchor;
+    } else {
+      var num = 0;
+      while (links[anchor]){
+        num++;
+        anchor = rawAnchor + ((num) ? '-'+num : '')
+      }
+      links[anchor] = anchor;
+      return anchor;
+    }
+  }
 
   while (src) {
     // newline
@@ -199,7 +218,8 @@ Lexer.prototype.token = function(src, top, bq) {
       this.tokens.push({
         type: 'heading',
         depth: cap[1].length,
-        text: cap[2]
+        text: cap[2],
+        anchor: uniqueAnchor(cap[2])
       });
       continue;
     }
@@ -242,7 +262,8 @@ Lexer.prototype.token = function(src, top, bq) {
       this.tokens.push({
         type: 'heading',
         depth: cap[2] === '=' ? 1 : 2,
-        text: cap[1]
+        text: cap[1],
+        anchor: uniqueAnchor(cap[1])
       });
       continue;
     }
@@ -785,12 +806,12 @@ Renderer.prototype.html = function(html) {
   return html;
 };
 
-Renderer.prototype.heading = function(text, level, raw) {
+Renderer.prototype.heading = function(text, level, raw, anchor) {
   return '<h'
     + level
     + ' id="'
     + this.options.headerPrefix
-    + raw.toLowerCase().replace(/[^\w]+/g, '-')
+    + anchor
     + '">'
     + text
     + '</h'
@@ -973,7 +994,8 @@ Parser.prototype.tok = function() {
       return this.renderer.heading(
         this.inline.output(this.token.text),
         this.token.depth,
-        this.token.text);
+        this.token.text,
+        this.token.anchor);
     }
     case 'code': {
       return this.renderer.code(this.token.text,

--- a/test/tests/duplicate_headers.html
+++ b/test/tests/duplicate_headers.html
@@ -1,0 +1,7 @@
+<h1 id="header">Header</h1>
+
+<h2 id="example">Example</h2>
+
+<h1 id="header-1">Header</h1>
+
+<h2 id="example-1">Example</h2>

--- a/test/tests/duplicate_headers.text
+++ b/test/tests/duplicate_headers.text
@@ -1,0 +1,7 @@
+# Header
+
+## Example
+
+# Header
+
+## Example


### PR DESCRIPTION
I am working on a table of contents generator using marked for another project and noticed that marked does not generate unique ids when headers in the same markdown contain the same text.

For example a link to `#examples` would always go to the first header.

```markdown
# Thing 1

## Examples

## Options

# Thing 2

## Examples

## Options
```

This PR changes the default behavior making to that duplicate headers are given incrementing integers so they are unique, `example-1`, `options-1` in my example.

This is probably a breaking change though since there is 1 failed test but I think its worthwhile since it brings the markdown behavior closer to Github which uses the same strategy to keep header ids unique.

#### Benchmarks

this does come at a small performance cost of ~250-300 milliseconds

##### unique-header-ids

```
marked completed in 3270ms.
marked (gfm) completed in 3504ms.
marked (pedantic) completed in 2968ms.
robotskirt completed in 620ms.
showdown (reuse converter) completed in 9196ms.
showdown (new converter) completed in 13454ms.
markdown.js completed in 14361ms.
```

##### master

```
marked completed in 3009ms.
marked (gfm) completed in 3251ms.
marked (pedantic) completed in 2760ms.
robotskirt completed in 592ms.
showdown (reuse converter) completed in 9018ms.
showdown (new converter) completed in 13270ms.
markdown.js completed in 13973ms.
```

##### Tests

I've added a test for this behavior but this change also causes the the top level paragraphs test to fail

https://github.com/chjj/marked/blob/master/test/tests/toplevel_paragraphs.gfm.text

This is because the header "how are you" header is repeated multiple times in the document so the ID no longer matches. If you want to merge this will change that test to pass.