### PR TITLE
Smartypants &ndash and &mdash

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -711,8 +711,10 @@ InlineLexer.prototype.outputLink = function(cap, link) {
 InlineLexer.prototype.smartypants = function(text) {
   if (!this.options.smartypants) return text;
   return text
-    // em-dashes
-    .replace(/--/g, '\u2014')
+    // em-dashes    
+    .replace(/---/g, '\u2014')
+    // en-dashes
+    .replace(/--/g, '\u2013')
     // opening singles
     .replace(/(^|[-\u2014/(\[{"\s])'/g, '$1\u2018')
     // closing singles & apostrophes

--- a/test/tests/text.smartypants.html
+++ b/test/tests/text.smartypants.html
@@ -1,4 +1,4 @@
-<p>Hello world ‘how’ “are” you — today…</p>
+<p>Hello world ‘how’ “are” you – today…</p>
 
 <p>“It’s a more ‘challenging’ smartypants test…”</p>
 

--- a/test/tests/text.smartypants.text
+++ b/test/tests/text.smartypants.text
@@ -2,5 +2,5 @@ Hello world 'how' "are" you -- today...
 
 "It's a more 'challenging' smartypants test..."
 
-'And,' as a bonus -- "one
+'And,' as a bonus --- "one
 multiline" test!


### PR DESCRIPTION
Hi,

according to [Gruber's
Smartypants](http://daringfireball.net/projects/smartypants/)
`--` result in an `&ndash;`(\u2013) and `---` in an `&mdash;`(\u2n14).

As far as I can tell, `marked` converts `--` into `&mdash;`