### PR TITLE
Add -mangle/-no-mangle to enable/disable mangling of email addresses.

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -730,6 +730,7 @@ InlineLexer.prototype.smartypants = function(text) {
  */
 
 InlineLexer.prototype.mangle = function(text) {
+  if (!this.options.mangle) return text;
   var out = ''
     , l = text.length
     , i = 0
@@ -1232,6 +1233,7 @@ marked.defaults = {
   breaks: false,
   pedantic: false,
   sanitize: false,
+  mangle: true,
   smartLists: false,
   silent: false,
   highlight: null,

--- a/man/marked.1
+++ b/man/marked.1
@@ -61,6 +61,9 @@ Use smarter list behavior than the original markdown.
 .BI \-\-lang\-prefix\ [\fIprefix\fP]
 Set the prefix for code block classes.
 .TP
+.BI \-\-mangle
+Mangle email addresses.
+.TP
 .BI \-\-no\-sanitize,\ \-no-etc...
 The inverse of any of the marked options above.
 .TP


### PR DESCRIPTION
Hello,

I write my email newsletters in Markdown and I don't want email addresses to be mangled (I think spam filters will have trouble with the mangling), so I introduced -mangle/-no-mangle option (-mangle is default).

Would you consider this for inclusion?

(Warning: no tests, could someone give me a hand on writing a test?)