### PR TITLE
Fix tiny typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ An object containing functions to render tokens to HTML.
 
 #### Overriding renderer methods
 
-The renderer option allows you to render tokens in a custom manor. Here is an
+The renderer option allows you to render tokens in a custom manner. Here is an
 example of overriding the default heading token rendering by adding an embedded anchor tag like on GitHub:
 
 ```javascript


### PR DESCRIPTION
Although `marked` should be the "main house or mansion on an estate, plantation, etc." of the Markdown world, unfortunately it's not.

This fixed a minor README typo: `manor` -> `matter`.