### PR TITLE
Fixes #538; Parse non-strings

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1133,6 +1133,10 @@ function merge(obj) {
  */
 
 function marked(src, opt, callback) {
+  if (typeof src != 'string' && typeof src.toString == 'function') {
+    src = src.toString()
+  }
+
   if (callback || typeof opt === 'function') {
     if (!callback) {
       callback = opt;

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1133,7 +1133,7 @@ function merge(obj) {
  */
 
 function marked(src, opt, callback) {
-  if (typeof src != 'string' && typeof src.toString == 'function') {
+  if (src && typeof src != 'string' && typeof src.toString == 'function') {
     src = src.toString()
   }
 


### PR DESCRIPTION
Current default behavior expects the `src` parameter of `marked` to be a string. While this is a pretty legitimate expectation, in JS there are many possible, perfectly valid, scenarios where this might not be the case (e.g. numbers).

This addresses the issue by adding a quick check at the top of `marked`. Basically if the `src` parameter is defined, not a string, and does have a `toString` method then we simply convert it to a string before parsing.