### PR TITLE
Correct version in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "marked",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "homepage": "https://github.com/chjj/marked",
   "authors": [
     "Christopher Jeffrey <chjjeffrey@gmail.com>"


### PR DESCRIPTION
Hey, while installing the package with Bower I noticed that package version was not updated in Bower file  (according to GitHub releases page and npmjs registry, now it is 0.3.3, while bower addresses 0.3.2). So this PR fixes this.