### PR TITLE
Added support for manual text node rendering

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -678,7 +678,7 @@ InlineLexer.prototype.output = function(src) {
     // text
     if (cap = this.rules.text.exec(src)) {
       src = src.substring(cap[0].length);
-      out += escape(this.smartypants(cap[0]));
+      out += this.renderer.text(escape(this.smartypants(cap[0])));
       continue;
     }
 
@@ -887,6 +887,10 @@ Renderer.prototype.image = function(href, title, text) {
   }
   out += this.options.xhtml ? '/>' : '>';
   return out;
+};
+
+Renderer.prototype.text = function(text) {
+  return text;
 };
 
 /**


### PR DESCRIPTION
This allows the rendering of text nodes to be overwritten. I've found this particularly useful in cases where I needed to escape certain character sequences in all text nodes.