### PR TITLE
typographic switch

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -710,19 +710,8 @@ InlineLexer.prototype.outputLink = function(cap, link) {
 
 InlineLexer.prototype.smartypants = function(text) {
   if (!this.options.smartypants) return text;
-  return text
-    // em-dashes
-    .replace(/--/g, '\u2014')
-    // opening singles
-    .replace(/(^|[-\u2014/(\[{"\s])'/g, '$1\u2018')
-    // closing singles & apostrophes
-    .replace(/'/g, '\u2019')
-    // opening doubles
-    .replace(/(^|[-\u2014/(\[{\u2018\s])"/g, '$1\u201c')
-    // closing doubles
-    .replace(/"/g, '\u201d')
-    // ellipses
-    .replace(/\.{3}/g, '\u2026');
+  var smartypants = require('./smartypants');
+  return smartypants(text);
 };
 
 /**

--- a/lib/smartypants.js
+++ b/lib/smartypants.js
@@ -1,0 +1,21 @@
+var compose = require('fn-compose');
+
+var ellipses = require('typographic-ellipses');
+var singleSpaces = require('typographic-single-spaces');
+
+var apostrophes = require('typographic-apostrophes');
+var quotes = require('typographic-quotes');
+var apostrophesForPlurals = require('typographic-apostrophes-for-possessive-plurals');
+
+var endashes = require('typographic-en-dashes');
+var emdashes = require('typographic-em-dashes');
+
+module.exports = compose(
+  apostrophes,
+  quotes,
+  apostrophesForPlurals,
+  endashes,
+  emdashes,
+  ellipses,
+  singleSpaces
+);

--- a/package.json
+++ b/package.json
@@ -18,5 +18,15 @@
     "showdown": "*",
     "robotskirt": "*"
   },
+  "dependencies": {
+    "fn-compose": "^1.0.0",
+    "typographic-apostrophes": "^1.0.0",
+    "typographic-apostrophes-for-possessive-plurals": "^1.0.0",
+    "typographic-ellipses": "^1.0.8",
+    "typographic-em-dashes": "^1.0.0",
+    "typographic-en-dashes": "^1.0.0",
+    "typographic-quotes": "^1.0.2",
+    "typographic-single-spaces": "^1.0.0"
+  },
   "scripts": { "test": "node test", "bench": "node test --bench" }
 }

--- a/test/new/text.smartypants.html
+++ b/test/new/text.smartypants.html
@@ -1,6 +1,6 @@
-<p>Hello world ‘how’ “are” you — today…</p>
+<p>Hello world “how” “are” you — today…</p>
 
 <p>“It’s a more ‘challenging’ smartypants test…”</p>
 
-<p>‘And,’ as a bonus — “one
+<p>“And,” as a bonus — “one
 multiline” test!</p>

--- a/test/tests/text.smartypants.html
+++ b/test/tests/text.smartypants.html
@@ -1,6 +1,6 @@
-<p>Hello world ‘how’ “are” you — today…</p>
+<p>Hello world “how” “are” you — today…</p>
 
 <p>“It’s a more ‘challenging’ smartypants test…”</p>
 
-<p>‘And,’ as a bonus — “one
+<p>“And,” as a bonus — “one
 multiline” test!</p>


### PR DESCRIPTION
Hey, I'm using your markdown compiler for a while and want to say thank you for it!

Btw, I’m little obsessed with typography and wrote a bunch of small, full tested and safe to use typographic modules. That’s why I’m wondering will you prefer to delegate typography to 3rd party packages and concentrate marked’s development only on parsing and compiling?

if no, it's fine, I understand. If yes, check out this pull-request and feel free to comment and ask me anything. Will look forward for your response.

PS. My origin idea of this pull-request was that compiler should not be responsible for typography, it should do well parsing and compiling and what do you think?