### PR TITLE
Added ignore() method to disable specific markup.

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1226,6 +1226,17 @@ marked.setOptions = function(opt) {
   return marked;
 };
 
+marked.ignore = function(items) {
+ var i = items.length;
+ while (i--) {
+  if (items[i] in block.normal) {
+    block.normal[items[i]] = noop;
+  } else if (items[i] in inline.normal) {
+    inline.normal[items[i]] = noop;
+  }
+ }
+};
+
 marked.defaults = {
   gfm: true,
   tables: true,


### PR DESCRIPTION
Works by re-assigning noop; gfm must be false.