### PR TITLE
Do not render strong or em when text contains tag

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -453,8 +453,8 @@ var inline = {
   link: /^!?\[(inside)\]\(href\)/,
   reflink: /^!?\[(inside)\]\s*\[([^\]]*)\]/,
   nolink: /^!?\[((?:\[[^\]]*\]|[^\[\]])*)\]/,
-  strong: /^__([\s\S]+?)__(?!_)|^\*\*([\s\S]+?)\*\*(?!\*)/,
-  em: /^\b_((?:__|[\s\S])+?)_\b|^\*((?:\*\*|[\s\S])+?)\*(?!\*)/,
+  strong: /^__((?:(?!tag)[\s\S])+?)__(?!_)|^\*\*((?:(?!tag)[\s\S])+?)\*\*(?!\*)/,
+  em: /^\b_((?:__|(?:(?!tag)[\s\S]))+?)_\b|^\*((?:\*\*|(?:(?!tag)[\s\S]))+?)\*(?!\*)/,
   code: /^(`+)\s*([\s\S]*?[^`])\s*\1(?!`)/,
   br: /^ {2,}\n(?!\s*$)/,
   del: noop,
@@ -472,6 +472,14 @@ inline.link = replace(inline.link)
 inline.reflink = replace(inline.reflink)
   ('inside', inline._inside)
   ();
+
+inline.strong = replace(inline.strong)
+  ('tag', inline.tag)
+  ();
+
+inline.em = replace(inline.em)
+  ('tag', inline.tag)
+  ();  
 
 /**
  * Normal Inline Grammar


### PR DESCRIPTION
Marked will render strong or em with a wrong output in below situation. We should not render strong or em when text contains tag.

```
<table>
  <tr>
    <td>Te__st</td>
    <td>Strin__g</td>
  </tr>
  <tr>
    <td>Te _st</td>
    <td>Strin_ g</td>
  </tr>
</table>
```
