### PR TITLE
allowing dot before extension

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -75,7 +75,7 @@ block.normal = merge({}, block);
  */
 
 block.gfm = merge({}, block.normal, {
-  fences: /^ *(`{3,}|~{3,}) *(\S+)? *\n([\s\S]+?)\s*\1 *(?:\n+|$)/,
+  fences: /^ *(`{3,}|~{3,})[ \.]*(\S+)? *\n([\s\S]+?)\s*\1 *(?:\n+|$)/,
   paragraph: /^/
 });
 


### PR DESCRIPTION
allowing dot before extension as github markdown
```.md
    ```.ext
        some code
    ```
```