### PR TITLE
Added a math parsing feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ marked.setOptions({
   pedantic: false,
   sanitize: true,
   smartLists: true,
-  smartypants: false
+  smartypants: false,
+  math: null
 });
 
 console.log(marked('I am using __markdown__.'));
@@ -141,6 +142,28 @@ The programming language specified in the code block.
 Type: `function`
 
 The callback function to call when using an async highlighter.
+
+### Math
+
+Type: { render: Function }
+
+An object with a `render` method that parses math expressions inside `$$ ... $$` blocks, or inline inside `$ ... $` expressions, and returns a rendered version. Here's an example with the [KaTeX](http://khan.github.io/KaTeX/) typesetter.
+
+```js
+marked.setOptions({
+  gfm: true,
+  math: {
+    render: function (tex) {
+      return katex.renderToString(tex);
+    }
+  }
+});
+
+marked(markdownString, function (err, content) {
+  if (err) { throw err; }
+  console.log(content);
+});
+```
 
 ### renderer
 

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -24,7 +24,8 @@ var block = {
   def: /^ *\[([^\]]+)\]: *<?([^\s>]+)>?(?: +["(]([^\n]+)[")])? *(?:\n+|$)/,
   table: noop,
   paragraph: /^((?:[^\n]+\n?(?!hr|heading|lheading|blockquote|tag|def))+)\n*/,
-  text: /^[^\n]+/
+  text: /^[^\n]+/,
+  tex: noop
 };
 
 block.bullet = /(?:[*+-]|\d+\.)/;
@@ -87,6 +88,23 @@ block.gfm.paragraph = replace(block.paragraph)
   ();
 
 /**
+ * Math Block Grammar
+ */
+
+block.math = merge({}, block.normal, {
+  tex: /^ *(\${2,}) *\n([\s\S]+?)\1 *(?:\n+|$)/
+});
+
+block.math.paragraph = replace(block.paragraph)
+  ('(?!', '(?!', '(?!',
+    + block.gfm.fences.source.replace('\\1', '\\2') + '|'
+    + block.math.tex.source.replace('\\1', '\\2') + '|'
+    + block.list.source.replace('\\1', '\\3') + '|')
+  ()
+
+block.mathgfm = merge({}, block.gfm, block.math);
+
+/**
  * GFM + Tables Block Grammar
  */
 
@@ -94,6 +112,8 @@ block.tables = merge({}, block.gfm, {
   nptable: /^ *(\S.*\|.*)\n *([-:]+ *\|[-| :]*)\n((?:.*\|.*(?:\n|$))*)\n*/,
   table: /^ *\|(.+)\n *\|( *[-:]+[-| :]*)\n((?: *\|.*(?:\n|$))*)\n*/
 });
+
+block.mathgfmtables = merge({}, block.tables, block.mathgfm);
 
 /**
  * Block Lexer
@@ -107,10 +127,20 @@ function Lexer(options) {
 
   if (this.options.gfm) {
     if (this.options.tables) {
-      this.rules = block.tables;
+      if (this.options.math) {
+        this.rules = block.mathgfmtables;
+      } else {
+        this.rules = block.tables;
+      }
     } else {
-      this.rules = block.gfm;
+      if (this.options.math) {
+        this.rules = block.mathgfm;
+      } else {
+        this.rules = block.gfm;
+      }
     }
+  } else if (this.options.math) {
+    this.rules = block.math;
   }
 }
 
@@ -190,6 +220,16 @@ Lexer.prototype.token = function(src, top, bq) {
         type: 'code',
         lang: cap[2],
         text: cap[3]
+      });
+      continue;
+    }
+
+    // math
+    if (cap = this.rules.tex.exec(src)) {
+      src = src.substring(cap[0].length);
+      this.tokens.push({
+        type: 'tex',
+        text: cap[2]
       });
       continue;
     }
@@ -784,6 +824,11 @@ Renderer.prototype.code = function(code, lang, escaped) {
     + '\n</code></pre>\n';
 };
 
+Renderer.prototype.tex = function(tex) {
+  // console.log(tex);
+  return this.options.math.render(tex);
+}
+
 Renderer.prototype.blockquote = function(quote) {
   return '<blockquote>\n' + quote + '</blockquote>\n';
 };
@@ -990,6 +1035,10 @@ Parser.prototype.tok = function() {
       return this.renderer.code(this.token.text,
         this.token.lang,
         this.token.escaped);
+    }
+    case 'tex': {
+      // console.log(this.token);
+      return this.renderer.tex(this.token.text);
     }
     case 'table': {
       var header = ''


### PR DESCRIPTION
The parser expects a block surrounded in `$$ ... $$` or an inline component surrounded in `$ ... $`. You supply the renderer, via a `math` option, which is an object with a `render` method that returns a string, representing the outputed math.

This is different from #180, in that the renderer is not limited to just MathJax, but KaTeX will work as well.
