### PR TITLE
changed regex to allow parenthesis in link names

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -464,7 +464,7 @@ var inline = {
 };
 
 inline._inside = /(?:\[[^\]]*\]|[^\[\]]|\](?=[^\[]*\]))*/;
-inline._href = /\s*<?([\s\S]*?)>?(?:\s+['"]([\s\S]*?)['"])?\s*/;
+inline._href = /\s*<?([\s\S]*)>?(?:\s+['"]([\s\S]*?)['"])?\s*/;
 
 inline.link = replace(inline.link)
   ('inside', inline._inside)


### PR DESCRIPTION
Before the patch, this:
[blabla](link%28text%29) would generate incorrect href="link(text" 

now it generate href="link(text)"

The fix is to make the regex greedy, so it takes all the characteres in the href until the last ')'
