### PR TITLE
More liberal language regex in fences

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -75,7 +75,7 @@ block.normal = merge({}, block);
  */
 
 block.gfm = merge({}, block.normal, {
-  fences: /^ *(`{3,}|~{3,})[ \.]*(\S+)? *\n([\s\S]+?)\s*\1 *(?:\n+|$)/,
+  fences: /^ *(`{3,}|~{3,})[ \.]*([^\n]+)? *\n([\s\S]+?)\s*\1 *(?:\n+|$)/,
   paragraph: /^/,
   heading: /^ *(#{1,6}) +([^\n]+?) *#* *(?:\n+|$)/
 });

--- a/test/tests/rmd_code.html
+++ b/test/tests/rmd_code.html
@@ -1,0 +1,6 @@
+<pre><code class="lang-{r}">summary(cars)</code></pre>
+<pre><code class="lang-{r simulate_data}">x &lt;- rnorm(100)
+y &lt;- 2*x + rnorm(100)</code></pre>
+<pre><code class="lang-{r chunk_name, echo=FALSE}">x &lt;- rnorm(100)
+y &lt;- 2*x + rnorm(100)
+cor(x, y)</code></pre>

--- a/test/tests/rmd_code.text
+++ b/test/tests/rmd_code.text
@@ -1,0 +1,14 @@
+```{r}
+summary(cars)
+```
+
+```{r simulate_data}
+x <- rnorm(100)
+y <- 2*x + rnorm(100)
+```
+
+```{r chunk_name, echo=FALSE}
+x <- rnorm(100)
+y <- 2*x + rnorm(100)
+cor(x, y)
+```


### PR DESCRIPTION
Addresses #606 by allowing for spaces in the "language" field. Users that want to read RMarkdown can follow this up with their own parsing logic.