### PR TITLE
Fixed parsing of empty code blocks.

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -75,7 +75,7 @@ block.normal = merge({}, block);
  */
 
 block.gfm = merge({}, block.normal, {
-  fences: /^ *(`{3,}|~{3,})[ \.]*(\S+)? *\n([\s\S]*?)\s*\1 *(?:\n+|$)/,
+  fences: /^ *(`{3,}|~{3,})[ \.]*(\S+)? *\n([\s\S]*?)\n\1 *(?:\n+|$)/,
   paragraph: /^/,
   heading: /^ *(#{1,6}) +([^\n]+?) *#* *(?:\n+|$)/
 });

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -75,7 +75,7 @@ block.normal = merge({}, block);
  */
 
 block.gfm = merge({}, block.normal, {
-  fences: /^ *(`{3,}|~{3,})[ \.]*(\S+)? *\n([\s\S]+?)\s*\1 *(?:\n+|$)/,
+  fences: /^ *(`{3,}|~{3,})[ \.]*(\S+)? *\n([\s\S]*?)\s*\1 *(?:\n+|$)/,
   paragraph: /^/,
   heading: /^ *(#{1,6}) +([^\n]+?) *#* *(?:\n+|$)/
 });

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -75,7 +75,7 @@ block.normal = merge({}, block);
  */
 
 block.gfm = merge({}, block.normal, {
-  fences: /^ *(`{3,}|~{3,})[ \.]*(\S+)? *\n([\s\S]*?)\n\1 *(?:\n+|$)/,
+  fences: /^ *(`{3,}|~{3,})[ \.]*(\S+)? *\n(?:([\s\S]*?)\n|)\1 *(?:\n+|$)/,
   paragraph: /^/,
   heading: /^ *(#{1,6}) +([^\n]+?) *#* *(?:\n+|$)/
 });
@@ -189,7 +189,7 @@ Lexer.prototype.token = function(src, top, bq) {
       this.tokens.push({
         type: 'code',
         lang: cap[2],
-        text: cap[3]
+        text: cap[3] || '' // will come out as undefined when the block is empty
       });
       continue;
     }

--- a/test/tests/gfm_code.html
+++ b/test/tests/gfm_code.html
@@ -5,3 +5,6 @@ console.log(a + &#39; world&#39;);</code></pre>
 <pre><code class="lang-ManyTildes">A longfence!</code></pre>
 <p>How about an empty code block?</p>
 <pre><code class="lang-js"></code></pre>
+<p>How about a code block with only an empty line?</p>
+<pre><code class="lang-js">
+</code></pre>

--- a/test/tests/gfm_code.html
+++ b/test/tests/gfm_code.html
@@ -3,3 +3,5 @@ console.log(a + &#39; world&#39;);</code></pre>
 <pre><code class="lang-bash">echo &quot;hello, ${WORLD}&quot;</code></pre>
 <pre><code class="lang-longfence">Q: What do you call a tall person who sells stolen goods?</code></pre>
 <pre><code class="lang-ManyTildes">A longfence!</code></pre>
+<p>How about an empty code block?</p>
+<pre><code class="lang-js"></code></pre>

--- a/test/tests/gfm_code.text
+++ b/test/tests/gfm_code.text
@@ -14,3 +14,8 @@ Q: What do you call a tall person who sells stolen goods?
 ~~~~~~~~~~  ManyTildes
 A longfence!
 ~~~~~~~~~~
+
+How about an empty code block?
+
+```js
+```

--- a/test/tests/gfm_code.text
+++ b/test/tests/gfm_code.text
@@ -19,3 +19,9 @@ How about an empty code block?
 
 ```js
 ```
+
+How about a code block with only an empty line?
+
+```js
+
+```


### PR DESCRIPTION
Fixes #615 

There's another test failing (def_blocks), but it was also failing before this fix.