### PR TITLE
Fix the default options example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ marked.setOptions({
   tables: true,
   breaks: false,
   pedantic: false,
-  sanitize: true,
-  smartLists: true,
+  sanitize: false,
+  smartLists: false,
   smartypants: false
 });
 


### PR DESCRIPTION
We have recently been attacked with XSS because we did not set marked's `sanitize` option. We did not set the `sanitize` option because the docs says that it is `true` by default in the example:

> Example setting options with default values:
> 
> ``` js
> var marked = require('marked');
> marked.setOptions({
>   renderer: new marked.Renderer(),
>   gfm: true,
>   tables: true,
>   breaks: false,
>   pedantic: false,
>   sanitize: true,
> ```

It is later stated in the docs that `sanitize` is `false` by default:

> ### sanitize
> 
> Type: `boolean`
> Default: `false`
