### PR TITLE
Fix sanitize default in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ marked.setOptions({
   tables: true,
   breaks: false,
   pedantic: false,
-  sanitize: true,
+  sanitize: false,
   smartLists: true,
   smartypants: false
 });


### PR DESCRIPTION
`sanitize: false` by default, according to https://github.com/chjj/marked/blob/18fb6a639a4a77dd59650879bcad10d833c40067/lib/marked.js#L1245
