### PR TITLE
Renderer HTML escaping

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -583,8 +583,7 @@ InlineLexer.prototype.output = function(src) {
           : this.mangle(cap[1]);
         href = this.mangle('mailto:') + text;
       } else {
-        text = escape(cap[1]);
-        href = text;
+        href = text = cap[1];
       }
       out += this.renderer.link(href, null, text);
       continue;
@@ -593,8 +592,7 @@ InlineLexer.prototype.output = function(src) {
     // url (gfm)
     if (!this.inLink && (cap = this.rules.url.exec(src))) {
       src = src.substring(cap[0].length);
-      text = escape(cap[1]);
-      href = text;
+      href = text = cap[1];
       out += this.renderer.link(href, null, text);
       continue;
     }
@@ -607,10 +605,8 @@ InlineLexer.prototype.output = function(src) {
         this.inLink = false;
       }
       src = src.substring(cap[0].length);
-      out += this.options.sanitize
-        ? this.options.sanitizer
-          ? this.options.sanitizer(cap[0])
-          : escape(cap[0])
+      out += this.options.sanitize && this.options.sanitizer
+        ? this.options.sanitizer(cap[0])
         : cap[0]
       continue;
     }
@@ -661,7 +657,7 @@ InlineLexer.prototype.output = function(src) {
     // code
     if (cap = this.rules.code.exec(src)) {
       src = src.substring(cap[0].length);
-      out += this.renderer.codespan(escape(cap[2], true));
+      out += this.renderer.codespan(cap[2]);
       continue;
     }
 
@@ -682,7 +678,7 @@ InlineLexer.prototype.output = function(src) {
     // text
     if (cap = this.rules.text.exec(src)) {
       src = src.substring(cap[0].length);
-      out += this.renderer.text(escape(this.smartypants(cap[0])));
+      out += this.renderer.text(this.smartypants(cap[0]));
       continue;
     }
 
@@ -700,12 +696,9 @@ InlineLexer.prototype.output = function(src) {
  */
 
 InlineLexer.prototype.outputLink = function(cap, link) {
-  var href = escape(link.href)
-    , title = link.title ? escape(link.title) : null;
-
   return cap[0].charAt(0) !== '!'
-    ? this.renderer.link(href, title, this.output(cap[1]))
-    : this.renderer.image(href, title, escape(cap[1]));
+    ? this.renderer.link(link.href, link.title, this.output(cap[1]), true)
+    : this.renderer.image(link.href, link.title, cap[1]);
 };
 
 /**
@@ -855,7 +848,7 @@ Renderer.prototype.em = function(text) {
 };
 
 Renderer.prototype.codespan = function(text) {
-  return '<code>' + text + '</code>';
+  return '<code>' + escape(text, true) + '</code>';
 };
 
 Renderer.prototype.br = function() {
@@ -866,7 +859,10 @@ Renderer.prototype.del = function(text) {
   return '<del>' + text + '</del>';
 };
 
-Renderer.prototype.link = function(href, title, text) {
+Renderer.prototype.link = function(href, title, text, escaped) {
+  href = escape(href);
+  title = title ? escape(title) : null;
+  text = escaped ? text : escape(text);
   if (this.options.sanitize) {
     try {
       var prot = decodeURIComponent(unescape(href))
@@ -888,6 +884,8 @@ Renderer.prototype.link = function(href, title, text) {
 };
 
 Renderer.prototype.image = function(href, title, text) {
+  href = escape(href);
+  title = title ? escape(title) : null;
   var out = '<img src="' + href + '" alt="' + text + '"';
   if (title) {
     out += ' title="' + title + '"';
@@ -897,7 +895,7 @@ Renderer.prototype.image = function(href, title, text) {
 };
 
 Renderer.prototype.text = function(text) {
-  return text;
+  return escape(text);
 };
 
 /**


### PR DESCRIPTION
Move escaping of HTML from `InlineLexer` to `Renderer`. This will
modularize marked further and allow using it with custom renderers that
do not intend to output HTML.
