### PR TITLE
Do not autolink a trailing "!" in a URL

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -496,7 +496,7 @@ inline.pedantic = merge({}, inline.normal, {
 
 inline.gfm = merge({}, inline.normal, {
   escape: replace(inline.escape)('])', '~|])')(),
-  url: /^(https?:\/\/[^\s<]+[^<.,:;"')\]\s])/,
+  url: /^(https?:\/\/[^\s<]+[^<.,:;"'!)\]\s])/,
   del: /^~~(?=\S)([\s\S]*?\S)~~/,
   text: replace(inline.text)
     (']|', '~]|')

--- a/test/tests/gfm_links.html
+++ b/test/tests/gfm_links.html
@@ -1,2 +1,10 @@
-<p>This should be a link:
-<a href="http://example.com/hello-world">http://example.com/hello-world</a>.</p>
+<p>link with . <a href="http://example.com/hello-world">http://example.com/hello-world</a>.
+link with ! <a href="http://example.com/hello-world">http://example.com/hello-world</a>!
+link with : <a href="http://example.com/hello-world">http://example.com/hello-world</a>:
+link with , <a href="http://example.com/hello-world">http://example.com/hello-world</a>,
+link with ; <a href="http://example.com/hello-world">http://example.com/hello-world</a>;
+link with &#39; <a href="http://example.com/hello-world">http://example.com/hello-world</a>&#39;
+link with &quot; <a href="http://example.com/hello-world">http://example.com/hello-world</a>&quot;
+link with ) <a href="http://example.com/hello-world">http://example.com/hello-world</a>)
+link with nothing <a href="http://example.com/hello-world">http://example.com/hello-world</a>
+</p>

--- a/test/tests/gfm_links.text
+++ b/test/tests/gfm_links.text
@@ -1,1 +1,9 @@
-This should be a link: http://example.com/hello-world.
+link with . http://example.com/hello-world.
+link with ! http://example.com/hello-world!
+link with : http://example.com/hello-world:
+link with , http://example.com/hello-world,
+link with ; http://example.com/hello-world;
+link with ' http://example.com/hello-world'
+link with " http://example.com/hello-world"
+link with ) http://example.com/hello-world)
+link with nothing http://example.com/hello-world


### PR DESCRIPTION
I noticed in another project that uses marked that the text "http://localtunnel.me!" was being turned into a link that incorrectly included the trailing "!".

This PR changes the gfm url regex to explicitly not include a trailing "!".

It also expands the tests for gfm links to test for all the possible ending punctuation that the regex doesn't capture as part of the link as well as a test for no trailing punctuation.

I wasn't sure what the correct behavior is for determining whether a character is part of a link or punctuation. The exclamation point is technically a valid character to use in a url, but so are the closing parens (`")"`) and single and double quote marks, which are also part of the [existing url regex](https://github.com/chjj/marked/blob/master/lib/marked.js#L499). It seems far more likely that a sentence written in markdown would end with a url followed by a "!" than that a url would end with a "!", though.

For reference, Rinku, the link-detecting library used by github's markdown gem, [allows "?", "!", ".", "," and ":" as trailing punctuation](https://github.com/vmg/rinku/blob/master/test/autolink_test.rb#L44-L46).
