### PR TITLE
Use SVG badge for NPM version

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A full-featured markdown parser and compiler, written in JavaScript. Built
 > for speed.
 
-[![NPM version](https://badge.fury.io/js/marked.png)][badge]
+[![NPM version](https://badge.fury.io/js/marked.svg)][badge]
 
 ## Install
 


### PR DESCRIPTION
Use SVG badge for NPM version instead of PNG for better clarity on retina / hi-dpi displays.
