### PR TITLE
Drop unused renderer argument.

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -917,8 +917,8 @@ function Parser(options) {
  * Static Parse Method
  */
 
-Parser.parse = function(src, options, renderer) {
-  var parser = new Parser(options, renderer);
+Parser.parse = function(src, options) {
+  var parser = new Parser(options);
   return parser.parse(src);
 };
 
@@ -927,7 +927,7 @@ Parser.parse = function(src, options, renderer) {
  */
 
 Parser.prototype.parse = function(src) {
-  this.inline = new InlineLexer(src.links, this.options, this.renderer);
+  this.inline = new InlineLexer(src.links, this.options);
   this.tokens = src.reverse();
 
   var out = '';


### PR DESCRIPTION
Neither Parser nor InlineLexer accept renderer aragument so don’t
pass it to them.  Caller can set options.renderer property instead.
