### PR TITLE
Avoid declaring the same variable twice.

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -148,8 +148,7 @@ Lexer.prototype.lex = function(src) {
  */
 
 Lexer.prototype.token = function(src, top, bq) {
-  var src = src.replace(/^ +$/gm, '')
-    , next
+  var next
     , loose
     , cap
     , bull
@@ -158,6 +157,7 @@ Lexer.prototype.token = function(src, top, bq) {
     , space
     , i
     , l;
+  src = src.replace(/^ +$/gm, '');
 
   while (src) {
     // newline


### PR DESCRIPTION
src is an argument to Lexer.prototype.token so there is no need to
declare it as a variable.  It doesn’t seem to do any harm, but some
linters/compilers (read: Closure Compiler) complain.  Since there’s
almost zero cost in getting rid of the duplicate declaration, do so.
