### PR TITLE
Add linksInNewTab config option of whether or not to open links in a new tab or not

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ marked.setOptions({
   pedantic: false,
   sanitize: true,
   smartLists: true,
-  smartypants: false
+  smartypants: false,
+  linksInNewTab: false
 });
 
 console.log(marked('I am using __markdown__.'));
@@ -266,6 +267,13 @@ Type: `boolean`
 Default: `false`
 
 Use "smart" typograhic punctuation for things like quotes and dashes.
+
+### linksInNewTab
+
+Type: `boolean`
+Default: `false`
+
+Open links in new tabs.
 
 ## Access to lexer and parser
 

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -883,6 +883,11 @@ Renderer.prototype.link = function(href, title, text) {
   if (title) {
     out += ' title="' + title + '"';
   }
+
+  if (this.options.linksInNewTab) {
+      out += ' target="_blank"';
+  }
+
   out += '>' + text + '</a>';
   return out;
 };
@@ -1252,7 +1257,8 @@ marked.defaults = {
   smartypants: false,
   headerPrefix: '',
   renderer: new Renderer,
-  xhtml: false
+  xhtml: false,
+  linksInNewTab: false
 };
 
 /**


### PR DESCRIPTION
I tested locally in the project I wanted to use this with:
- by default it behaves the as it does now: links open in the same tab/window
- setting it to true via `setOptions`: links opens in a new tab/window
- setting it to false via `setOptions`:  links open in the same tab/window

Also, checked the README entry by looking at it on github.

Unit tests would be nice but I don't have time to grok how the tests work in this repo and other stuff is also not unit tested (e.g. `smartLists`)
