### PR TITLE
Add an option to disable markdown elements

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -114,7 +114,7 @@ function Lexer(options) {
   }
   
   for(var i = 0; i < this.options.disabledElements.length; i++) {
-    this.rules[this.options.disabledElements[i]].exec = function() {};
+    this.rules[this.options.disabledElements[i]] = noop;
   }
 }
 

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -112,6 +112,10 @@ function Lexer(options) {
       this.rules = block.gfm;
     }
   }
+  
+  for(var i = 0; i < this.options.disabledElements.length; i++) {
+    this.rules[this.options.disabledElements[i]].exec = function() {};
+  }
 }
 
 /**
@@ -1252,7 +1256,8 @@ marked.defaults = {
   smartypants: false,
   headerPrefix: '',
   renderer: new Renderer,
-  xhtml: false
+  xhtml: false,
+  disabledElements: []
 };
 
 /**


### PR DESCRIPTION
A simple change that let you disable any markdown element.
It's better creating an option than using [unsafe tricks and hacks](https://github.com/chjj/marked/issues/420#issuecomment-44746538)

## Examples

```javascript
marked.setOptions({
    disabledElements: ['hr', 'heading', 'list']
});

marked('---'); // Returns "---"
marked('# I am not a heading'); // Returns "# I am not a heading"
marked('* Item'); // Returns "* Item"
```