### PR TITLE
Throw error on non-string input

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1144,6 +1144,9 @@ function merge(obj) {
  */
 
 function marked(src, opt, callback) {
+  // return null in case of non valid input
+  if (typeof src != 'string') return null;
+
   if (callback || typeof opt === 'function') {
     if (!callback) {
       callback = opt;

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1144,8 +1144,13 @@ function merge(obj) {
  */
 
 function marked(src, opt, callback) {
-  // return null in case of non valid input
-  if (typeof src != 'string') return null;
+  // throw error in case of non string input
+  if (typeof src == 'undefined' || src === null)
+    throw new Error('marked(): input parameter is undefined or null');
+  if (typeof src != 'string')
+    throw new Error('marked(): input parameter is of type ' +
+      Object.prototype.toString.call(src) + ', string expected');
+
 
   if (callback || typeof opt === 'function') {
     if (!callback) {


### PR DESCRIPTION
I agree with what @scottgonzalez said here: https://github.com/chjj/marked/issues/417#issuecomment-42740178

I chose to return `null` instead of an empty string in order to let the user know there's a problem, and that it's probably his fault.

The `TypeError` is still thrown if a user calls manually `Lexer.lex` and then `Parser.parse`, but I think it's her/his business at this point.

fixes #168 fixes #417 fixes #447 fixes #291 fixes #442 fixes #635 fixes #658
fixes #681 fixes #755 fixes #758 fixes #776 fixes #787 fixes #794 fixes #802
fixes #934 fixes #867 fixes #903 fixes #955 fixes #1021 