### PR TITLE
Fix smartypants test inputs.

### DIFF
--- a/test/new/text.smartypants.html
+++ b/test/new/text.smartypants.html
@@ -1,4 +1,4 @@
-<p>Hello world ‘how’ “are” you — today…</p>
+<p>Hello world ‘how’ “are” you – today…</p>
 
 <p>“It’s a more ‘challenging’ smartypants test…”</p>
 

--- a/test/new/text.smartypants.text
+++ b/test/new/text.smartypants.text
@@ -2,5 +2,5 @@ Hello world 'how' "are" you -- today...
 
 "It's a more 'challenging' smartypants test..."
 
-'And,' as a bonus -- "one
+'And,' as a bonus --- "one
 multiline" test!


### PR DESCRIPTION
The `text.smartypants` tests differ between the `test/tests` and `test/new` directories (so after `node test --fix`, `node test` fails the smartypants tests). The `test/tests` versions appear to be the right ones.
