### PR TITLE
add chinese character range to heading escape regexp

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -797,7 +797,7 @@ Renderer.prototype.heading = function(text, level, raw) {
     + level
     + ' id="'
     + this.options.headerPrefix
-    + raw.toLowerCase().replace(/[^\w]+/g, '-')
+    + raw.toLowerCase().replace(/[^\w\u4e00-\u9eff]+/g, '-')  // \u4e00-\u9eff is common chinese character range
     + '">'
     + text
     + '</h'


### PR DESCRIPTION
It allow marked render Chinese by default like that:

``` markdown
## 灵活性
```

to this:

``` html
<h2 id="灵活性">灵活性</h2>
```

instead of:

``` html
<h2 id="-">灵活性</h2>
```
