### PR TITLE
Update default value for sanitize option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ marked.setOptions({
   tables: true,
   breaks: false,
   pedantic: false,
-  sanitize: true,
+  sanitize: false,
   smartLists: true,
   smartypants: false
 });


### PR DESCRIPTION
The default value of `sanitize` is `false` according to the description of `sanitize` (line 251 of README.md), but the example still listed `true` as the default value. A small test pointed out that the default value is indeed `false`.