### PR TITLE
Added whitelist tag support to work alongside sanitizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ marked.setOptions({
   breaks: false,
   pedantic: false,
   sanitize: true,
+  sanitizeWhitelist: [],
   smartLists: true,
   smartypants: false
 });
@@ -251,6 +252,15 @@ Type: `boolean`
 Default: `false`
 
 Sanitize the output. Ignore any HTML that has been input.
+
+### sanitizeWhitelist
+
+Type: `Array`
+Default: `[]`
+
+Use in conjunction with `sanitize: true`. A whitelist of HTML tags to
+allow through the sanitizer without encoding.
+Example: `['strong', 'span', 'div']`
 
 ### smartLists
 

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -523,6 +523,15 @@ function InlineLexer(links, options) {
   this.rules = inline.normal;
   this.renderer = this.options.renderer || new Renderer;
   this.renderer.options = this.options;
+  this.whitelistTags = {};
+  var i, tagLower;
+  if(this.options.sanitizeWhitelist && this.options.sanitizeWhitelist.length) {
+    for(i = 0; i < this.options.sanitizeWhitelist.length; i++) {
+      tagLower = ("" + this.options.sanitizeWhitelist[i]).toLowerCase();
+      this.whitelistTags["<"+tagLower] = true;
+      this.whitelistTags["</"+tagLower] = true;
+    }
+  }
 
   if (!this.links) {
     throw new
@@ -564,7 +573,9 @@ InlineLexer.prototype.output = function(src) {
     , link
     , text
     , href
-    , cap;
+    , cap
+    , spaceIndex
+    , tagStart;
 
   while (src) {
     // escape
@@ -607,7 +618,9 @@ InlineLexer.prototype.output = function(src) {
         this.inLink = false;
       }
       src = src.substring(cap[0].length);
-      out += this.options.sanitize
+      spaceIndex = cap[0].indexOf(" ");
+      tagStart = cap[0].substr(0, ~spaceIndex ? spaceIndex : cap[0].indexOf(">")).toLowerCase();
+      out += this.options.sanitize && this.whitelistTags[tagStart] !== true
         ? this.options.sanitizer
           ? this.options.sanitizer(cap[0])
           : escape(cap[0])


### PR DESCRIPTION
Addresses #133.

This is a similar PR to that in #536, except it uses an object literal for the whitelist rather than a Regular Expression. Sample usage:

``` javascript
marked("<div class='a'>Some <strong>small</strong> text</div><script>alert('a script');</script>", {
    sanitize: true,
    sanitizeWhitelist: ["div"]
});
```

Output:

``` html
<p>
    <div class='a'>
        Some &lt;strong&gt;small&lt;/strong&gt; text
    </div>
    &lt;script&gt;alert(&#39;a script&#39;);&lt;/script&gt;
</p>
```

The tests aren't very well set up for passing complex parameters (array of strings) through to the options so I've left those out. If someone can explain how I can add these in, I'll be happy to update the PR.
