### PR TITLE
Remove "preferGlobal" from "package.json" file

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@
 npm install marked --save
 ```
 
+or if you want to use the `marked` CLI tool:
+
+``` bash
+npm install -g marked
+```
+
 ## Usage
 
 Minimal usage:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "main": "./lib/marked.js",
   "bin": "./bin/marked",
   "man": "./man/marked.1",
-  "preferGlobal": true,
   "repository": "git://github.com/chjj/marked.git",
   "homepage": "https://github.com/chjj/marked",
   "bugs": { "url": "http://github.com/chjj/marked/issues" },


### PR DESCRIPTION
This PR removes the `preferGlobal` flag from the `package.json` file.

This project is used in library-mode by quite a few other projects like `node-notifier` and `testem`. Installing these other projects via NPM however results in the following warning:
```
npm WARN prefer global marked@0.3.5 should be installed with -g
```

There are basically two ways to resolve this warning:

- split the library code from the cli code
- make sure people understand that they can only use the cli tool if they install globally (can be done in the README file) and remove the `preferGlobal` flag

Since splitting the library is a lot more (unnecessary) work I'm proposing the second solution.

---

Resolves https://github.com/chjj/marked/issues/652 as well as e.g.:

- https://github.com/senecajs/seneca/issues/313
- https://github.com/ember-cli/ember-cli/issues/5539