### PR TITLE
Output to custom object

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -555,12 +555,20 @@ InlineLexer.output = function(src, links, options) {
   return inline.output(src);
 };
 
+InlineLexer.prototype.add = function(dest, content) {
+    if (dest === undefined) {
+        dest = '';
+    }
+    dest += content;
+    return dest;
+};
+
 /**
  * Lexing/Compiling
  */
 
 InlineLexer.prototype.output = function(src) {
-  var out = ''
+  var out
     , link
     , text
     , href
@@ -570,7 +578,7 @@ InlineLexer.prototype.output = function(src) {
     // escape
     if (cap = this.rules.escape.exec(src)) {
       src = src.substring(cap[0].length);
-      out += cap[1];
+      out = this.add(out, cap[1]);
       continue;
     }
 
@@ -586,7 +594,7 @@ InlineLexer.prototype.output = function(src) {
         text = escape(cap[1]);
         href = text;
       }
-      out += this.renderer.link(href, null, text);
+      out = this.add(out, this.renderer.link(href, null, text));
       continue;
     }
 
@@ -595,7 +603,7 @@ InlineLexer.prototype.output = function(src) {
       src = src.substring(cap[0].length);
       text = escape(cap[1]);
       href = text;
-      out += this.renderer.link(href, null, text);
+      out = this.add(out, this.renderer.link(href, null, text));
       continue;
     }
 
@@ -607,11 +615,11 @@ InlineLexer.prototype.output = function(src) {
         this.inLink = false;
       }
       src = src.substring(cap[0].length);
-      out += this.options.sanitize
+      out = this.add(out, this.options.sanitize
         ? this.options.sanitizer
           ? this.options.sanitizer(cap[0])
           : escape(cap[0])
-        : cap[0]
+        : cap[0]);
       continue;
     }
 
@@ -619,10 +627,10 @@ InlineLexer.prototype.output = function(src) {
     if (cap = this.rules.link.exec(src)) {
       src = src.substring(cap[0].length);
       this.inLink = true;
-      out += this.outputLink(cap, {
+      out = this.add(out, this.outputLink(cap, {
         href: cap[2],
         title: cap[3]
-      });
+      }));
       this.inLink = false;
       continue;
     }
@@ -634,12 +642,12 @@ InlineLexer.prototype.output = function(src) {
       link = (cap[2] || cap[1]).replace(/\s+/g, ' ');
       link = this.links[link.toLowerCase()];
       if (!link || !link.href) {
-        out += cap[0].charAt(0);
+        out = this.add(out, cap[0].charAt(0));
         src = cap[0].substring(1) + src;
         continue;
       }
       this.inLink = true;
-      out += this.outputLink(cap, link);
+      out = this.add(out, this.outputLink(cap, link));
       this.inLink = false;
       continue;
     }
@@ -647,42 +655,42 @@ InlineLexer.prototype.output = function(src) {
     // strong
     if (cap = this.rules.strong.exec(src)) {
       src = src.substring(cap[0].length);
-      out += this.renderer.strong(this.output(cap[2] || cap[1]));
+      out = this.add(out, this.renderer.strong(this.output(cap[2] || cap[1])));
       continue;
     }
 
     // em
     if (cap = this.rules.em.exec(src)) {
       src = src.substring(cap[0].length);
-      out += this.renderer.em(this.output(cap[2] || cap[1]));
+      out = this.add(out, this.renderer.em(this.output(cap[2] || cap[1])));
       continue;
     }
 
     // code
     if (cap = this.rules.code.exec(src)) {
       src = src.substring(cap[0].length);
-      out += this.renderer.codespan(escape(cap[2], true));
+      out = this.add(out, this.renderer.codespan(escape(cap[2], true)));
       continue;
     }
 
     // br
     if (cap = this.rules.br.exec(src)) {
       src = src.substring(cap[0].length);
-      out += this.renderer.br();
+      out = this.add(out, this.renderer.br());
       continue;
     }
 
     // del (gfm)
     if (cap = this.rules.del.exec(src)) {
       src = src.substring(cap[0].length);
-      out += this.renderer.del(this.output(cap[1]));
+      out = this.add(out, this.renderer.del(this.output(cap[1])));
       continue;
     }
 
     // text
     if (cap = this.rules.text.exec(src)) {
       src = src.substring(cap[0].length);
-      out += this.renderer.text(escape(this.smartypants(cap[0])));
+      out = this.add(out,this.renderer.text(escape(this.smartypants(cap[0]))));
       continue;
     }
 
@@ -922,6 +930,14 @@ Parser.parse = function(src, options, renderer) {
   return parser.parse(src);
 };
 
+Parser.prototype.processTokens = function() {
+  var out = '';
+  while (this.next()) {
+    out += this.tok();
+  }
+  return out;
+};
+
 /**
  * Parse Loop
  */
@@ -930,12 +946,7 @@ Parser.prototype.parse = function(src) {
   this.inline = new InlineLexer(src.links, this.options, this.renderer);
   this.tokens = src.reverse();
 
-  var out = '';
-  while (this.next()) {
-    out += this.tok();
-  }
-
-  return out;
+  return this.processTokens();
 };
 
 /**


### PR DESCRIPTION
I would like to create a custom output (not only a string) from the marked. e.g `marked('### ooo')` results to `{tag:'h3', children: 'ooo'`}. The `InlineLexer` and `Parser` works works with string output. 

Now, by overriding `InlineLexer.add` and `Parser.processTokens`, you are able to set custom output (with a custom `Renderer` as well).  Could be done like this: 

```javascript
marked.Parser.prototype.processTokens = function() {

    var out = [];
    while (this.next()) {
        out.push(this.tok());
    }

    return out;
};

marked.InlineLexer.prototype.add = function(out, content) {
    out = out || [];
    out.push(content);
    return out;
};

marked.Renderer.prototype.heading = function(text, level, raw) {
    return { tag: 'h' + level, children: text };
};
``` 