### PR TITLE
GFM paragraph lexer should use GFM heading regex

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -55,6 +55,32 @@ block.html = replace(block.html)
   (/tag/g, block._tag)
   ();
 
+/**
+ * GFM Block Grammar
+ */
+
+block.gfm = merge({}, block, {
+  fences: /^ *(`{3,}|~{3,})[ \.]*(\S+)? *\n([\s\S]*?)\s*\1 *(?:\n+|$)/,
+  paragraph: /^/,
+  heading: /^ *(#{1,6}) +([^\n]+?) *#* *(?:\n+|$)/
+});
+
+block.gfm.paragraph = replace(block.paragraph)
+  ('hr', block.hr)
+  ('heading', block.gfm.heading)
+  ('lheading', block.lheading)
+  ('blockquote', block.blockquote)
+  ('tag', '<' + block._tag)
+  ('def', block.def)
+  ('(?!', '(?!'
+    + block.gfm.fences.source.replace('\\1', '\\2') + '|'
+    + block.list.source.replace('\\1', '\\3') + '|')
+  ();
+
+/**
+ * Normal Block Grammar
+ */
+
 block.paragraph = replace(block.paragraph)
   ('hr', block.hr)
   ('heading', block.heading)
@@ -64,27 +90,7 @@ block.paragraph = replace(block.paragraph)
   ('def', block.def)
   ();
 
-/**
- * Normal Block Grammar
- */
-
 block.normal = merge({}, block);
-
-/**
- * GFM Block Grammar
- */
-
-block.gfm = merge({}, block.normal, {
-  fences: /^ *(`{3,}|~{3,})[ \.]*(\S+)? *\n([\s\S]*?)\s*\1 *(?:\n+|$)/,
-  paragraph: /^/,
-  heading: /^ *(#{1,6}) +([^\n]+?) *#* *(?:\n+|$)/
-});
-
-block.gfm.paragraph = replace(block.paragraph)
-  ('(?!', '(?!'
-    + block.gfm.fences.source.replace('\\1', '\\2') + '|'
-    + block.list.source.replace('\\1', '\\3') + '|')
-  ();
 
 /**
  * GFM + Tables Block Grammar


### PR DESCRIPTION
GFM paragraph regex was checking for headings in the non-GFM format,
which caused an extra paragraph break to be inserted, for example, in
the text:

```
print_hi('Tom')
#=> prints 'Hi, Tom' to STDOUT.
```
