### PR TITLE
Fix a bug in lexer which may cause empty table drop last cell

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -385,7 +385,7 @@ Lexer.prototype.token = function(src, top, bq) {
         type: 'table',
         header: cap[1].replace(/^ *| *\| *$/g, '').split(/ *\| */),
         align: cap[2].replace(/^ *|\| *$/g, '').split(/ *\| */),
-        cells: cap[3].replace(/(?: *\| *)?\n$/, '').split('\n')
+        cells: cap[3].replace(/( *\| *)?\n$/, '$1').split('\n')
       };
 
       for (i = 0; i < item.align.length; i++) {


### PR DESCRIPTION
The regex in marked.js:388 tends to trim the trail '\n' in markdown
table by using non marked match(?:). But it also destory the table
structure itself by mistake. So fix it by keeping the table structure.
