### PR TITLE
Don't redeclare parameter variable

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -148,8 +148,7 @@ Lexer.prototype.lex = function(src) {
  */
 
 Lexer.prototype.token = function(src, top, bq) {
-  var src = src.replace(/^ +$/gm, '')
-    , next
+  var next
     , loose
     , cap
     , bull
@@ -158,6 +157,7 @@ Lexer.prototype.token = function(src, top, bq) {
     , space
     , i
     , l;
+  src = src.replace(/^ +$/gm, '');
 
   while (src) {
     // newline


### PR DESCRIPTION
This causes the Closure Compiler to fail in strict mode.
