### PR TITLE
gfm headings regex should allow no space after hashes

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -77,7 +77,7 @@ block.normal = merge({}, block);
 block.gfm = merge({}, block.normal, {
   fences: /^ *(`{3,}|~{3,})[ \.]*(\S+)? *\n([\s\S]*?)\s*\1 *(?:\n+|$)/,
   paragraph: /^/,
-  heading: /^ *(#{1,6}) +([^\n]+?) *#* *(?:\n+|$)/
+  heading: /^ *(#{1,6})\s*([^\n]+?) *#* *(?:\n+|$)/
 });
 
 block.gfm.paragraph = replace(block.paragraph)


### PR DESCRIPTION
```
# heading
#heading
```

headings with no space between hash and words should work with github flavoured markdown
