### PR TITLE
Pass header flag to Renderer.tablerow method

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1009,7 +1009,9 @@ Parser.prototype.tok = function() {
           { header: true, align: this.token.align[i] }
         );
       }
-      header += this.renderer.tablerow(cell);
+      // header flag is not used in Renderer.prototype.tablerow, but passed
+      // here to make available to Renderer subclasses.
+      header += this.renderer.tablerow(cell, {header: true});
 
       for (i = 0; i < this.token.cells.length; i++) {
         row = this.token.cells[i];
@@ -1022,7 +1024,7 @@ Parser.prototype.tok = function() {
           );
         }
 
-        body += this.renderer.tablerow(cell);
+        body += this.renderer.tablerow(cell, {header: false});
       }
       return this.renderer.table(header, body);
     }


### PR DESCRIPTION
When styling tables out of a custom renderer subclass, it's useful to
know if the tablerow is in the header or body. Tablecells already get a
header flag that is set if the tablecell is in the header. This change
adds the flag to tablerows.
