### PR TITLE
Make erroneous / dangerous links display as text only

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -873,10 +873,10 @@ Renderer.prototype.link = function(href, title, text) {
         .replace(/[^\w:]/g, '')
         .toLowerCase();
     } catch (e) {
-      return '';
+      return text;
     }
     if (prot.indexOf('javascript:') === 0 || prot.indexOf('vbscript:') === 0 || prot.indexOf('data:') === 0) {
-      return '';
+      return text;
     }
   }
   var out = '<a href="' + href + '"';

--- a/test/tests/gfm_links_invalid.sanitize.html
+++ b/test/tests/gfm_links_invalid.sanitize.html
@@ -1,0 +1,1 @@
+<p>This should not be linked: http://example.com/%ff</p>

--- a/test/tests/gfm_links_invalid.sanitize.text
+++ b/test/tests/gfm_links_invalid.sanitize.text
@@ -1,0 +1,1 @@
+This should not be linked: http://example.com/%ff

--- a/test/tests/links.sanitize.html
+++ b/test/tests/links.sanitize.html
@@ -1,5 +1,5 @@
-<p></p>
-<p></p>
-<p></p>
-<p></p>
-<p></p>
+<p>URL</p>
+<p>URL</p>
+<p>URL</p>
+<p>URL</p>
+<p>URL</p>


### PR DESCRIPTION
**TL;DR:** Leaves link text but removes hyperlink.

## Explanation

Currently when there is a link that either cannot be parsed, or is detected to be potentially malicious, **marked** simply hides the entire link. For example, if I had the following markdown:

```
For help: [Click Here](data:text/html,lkjasdjflkasd==).
```

the output would be the following:

> For help: .

_This is especially problematic_ when URLs are automatically converted to links. For example:

```
http://example.com
```

Would automatically become:

> http://example.com

If for some reason the URL cannot be parsed, then the URL simply does not display at all. This happens if it has un-urlencoded characters etc., or if it otherwise cannot be parsed, but _was_ identified as a URL by the separate lexer.