### PR TITLE
Removed redundant code

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -997,13 +997,11 @@ Parser.prototype.tok = function() {
         , i
         , row
         , cell
-        , flags
         , j;
 
       // header
       cell = '';
       for (i = 0; i < this.token.header.length; i++) {
-        flags = { header: true, align: this.token.align[i] };
         cell += this.renderer.tablecell(
           this.inline.output(this.token.header[i]),
           { header: true, align: this.token.align[i] }


### PR DESCRIPTION
Small fix; I noticed that flags are not used, so I removed it. Flags are hardcoded as parameter in `tablecell`.