### PR TITLE
Fix error message typo

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1220,7 +1220,7 @@ function marked(src, opt, callback) {
   } catch (e) {
     e.message += '\nPlease report this to https://github.com/chjj/marked.';
     if ((opt || marked.defaults).silent) {
-      return '<p>An error occured:</p><pre>'
+      return '<p>An error occurred:</p><pre>'
         + escape(e.message + '', true)
         + '</pre>';
     }


### PR DESCRIPTION
Typo fix: changes "occured" to **occurred**