### PR TITLE
Add line number support to Lexer.token()

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -147,7 +147,7 @@ Lexer.prototype.lex = function(src) {
  * Lexing
  */
 
-Lexer.prototype.token = function(src, top, bq) {
+Lexer.prototype.token = function(src, top, bq, ln) {
   var src = src.replace(/^ +$/gm, '')
     , next
     , loose
@@ -159,49 +159,70 @@ Lexer.prototype.token = function(src, top, bq) {
     , i
     , l;
 
+  var lineNumber = this.options.lineNumber;
+  var lines = lineNumber ? 
+    function(content) {
+      return content.split('\n').length - 1;
+    } : 
+    function() { return 0; };
+
+  var tokens = this.tokens;
+  var push = function(token) {
+    if (lineNumber) {
+      token.ln = ln;
+    }
+    tokens.push(token);
+  };
+
+  ln = ln || 1;
+
   while (src) {
     // newline
     if (cap = this.rules.newline.exec(src)) {
       src = src.substring(cap[0].length);
       if (cap[0].length > 1) {
-        this.tokens.push({
+        push({
           type: 'space'
         });
       }
+      ln += lines(cap[0]);
     }
 
     // code
     if (cap = this.rules.code.exec(src)) {
       src = src.substring(cap[0].length);
       cap = cap[0].replace(/^ {4}/gm, '');
-      this.tokens.push({
+      push({
         type: 'code',
         text: !this.options.pedantic
           ? cap.replace(/\n+$/, '')
           : cap
       });
+      ln += lines(cap[0]);
       continue;
     }
 
     // fences (gfm)
     if (cap = this.rules.fences.exec(src)) {
       src = src.substring(cap[0].length);
-      this.tokens.push({
+      push({
         type: 'code',
         lang: cap[2],
         text: cap[3] || ''
       });
+      ln += lines(cap[0]);
       continue;
     }
 
     // heading
     if (cap = this.rules.heading.exec(src)) {
       src = src.substring(cap[0].length);
-      this.tokens.push({
+      push({
         type: 'heading',
         depth: cap[1].length,
         text: cap[2]
       });
+      ln += lines(cap[0]);
       continue;
     }
 
@@ -232,7 +253,8 @@ Lexer.prototype.token = function(src, top, bq) {
         item.cells[i] = item.cells[i].split(/ *\| */);
       }
 
-      this.tokens.push(item);
+      push(item);
+      ln += lines(cap[0]);
 
       continue;
     }
@@ -240,20 +262,22 @@ Lexer.prototype.token = function(src, top, bq) {
     // lheading
     if (cap = this.rules.lheading.exec(src)) {
       src = src.substring(cap[0].length);
-      this.tokens.push({
+      push({
         type: 'heading',
         depth: cap[2] === '=' ? 1 : 2,
         text: cap[1]
       });
+      ln += lines(cap[0]);
       continue;
     }
 
     // hr
     if (cap = this.rules.hr.exec(src)) {
       src = src.substring(cap[0].length);
-      this.tokens.push({
+      push({
         type: 'hr'
       });
+      ln += lines(cap[0]);
       continue;
     }
 
@@ -261,7 +285,7 @@ Lexer.prototype.token = function(src, top, bq) {
     if (cap = this.rules.blockquote.exec(src)) {
       src = src.substring(cap[0].length);
 
-      this.tokens.push({
+      push({
         type: 'blockquote_start'
       });
 
@@ -270,9 +294,10 @@ Lexer.prototype.token = function(src, top, bq) {
       // Pass `top` to keep the current
       // "toplevel" state. This is exactly
       // how markdown.pl works.
-      this.token(cap, top, true);
+      this.token(cap, top, true, ln);
+      ln += lines(cap);
 
-      this.tokens.push({
+      push({
         type: 'blockquote_end'
       });
 
@@ -284,7 +309,10 @@ Lexer.prototype.token = function(src, top, bq) {
       src = src.substring(cap[0].length);
       bull = cap[2];
 
-      this.tokens.push({
+      // calculate the end line number for the list
+      var endln = ln + lines(cap[0]);
+
+      push({
         type: 'list_start',
         ordered: bull.length > 1
       });
@@ -331,22 +359,26 @@ Lexer.prototype.token = function(src, top, bq) {
           next = item.charAt(item.length - 1) === '\n';
           if (!loose) loose = next;
         }
-
-        this.tokens.push({
+        push({
           type: loose
             ? 'loose_item_start'
             : 'list_item_start'
         });
 
         // Recurse.
-        this.token(item, false, bq);
+        this.token(item, false, bq, ln);
 
-        this.tokens.push({
+        ln += lines(item);
+
+        push({
           type: 'list_item_end'
         });
+        // list item will eat one line
+        ln++;
       }
 
-      this.tokens.push({
+      ln = endln;
+      push({
         type: 'list_end'
       });
 
@@ -356,7 +388,7 @@ Lexer.prototype.token = function(src, top, bq) {
     // html
     if (cap = this.rules.html.exec(src)) {
       src = src.substring(cap[0].length);
-      this.tokens.push({
+      push({
         type: this.options.sanitize
           ? 'paragraph'
           : 'html',
@@ -364,6 +396,7 @@ Lexer.prototype.token = function(src, top, bq) {
           && (cap[1] === 'pre' || cap[1] === 'script' || cap[1] === 'style'),
         text: cap[0]
       });
+      ln += lines(cap[0]);
       continue;
     }
 
@@ -374,6 +407,7 @@ Lexer.prototype.token = function(src, top, bq) {
         href: cap[2],
         title: cap[3]
       };
+      ln += lines(cap[0]);
       continue;
     }
 
@@ -387,6 +421,7 @@ Lexer.prototype.token = function(src, top, bq) {
         align: cap[2].replace(/^ *|\| *$/g, '').split(/ *\| */),
         cells: cap[3].replace(/(?: *\| *)?\n$/, '').split('\n')
       };
+      ln += lines(cap[0]);
 
       for (i = 0; i < item.align.length; i++) {
         if (/^ *-+: *$/.test(item.align[i])) {
@@ -406,7 +441,7 @@ Lexer.prototype.token = function(src, top, bq) {
           .split(/ *\| */);
       }
 
-      this.tokens.push(item);
+      push(item);
 
       continue;
     }
@@ -414,12 +449,13 @@ Lexer.prototype.token = function(src, top, bq) {
     // top-level paragraph
     if (top && (cap = this.rules.paragraph.exec(src))) {
       src = src.substring(cap[0].length);
-      this.tokens.push({
+      push({
         type: 'paragraph',
         text: cap[1].charAt(cap[1].length - 1) === '\n'
           ? cap[1].slice(0, -1)
           : cap[1]
       });
+      ln += lines(cap[0]);
       continue;
     }
 
@@ -427,10 +463,11 @@ Lexer.prototype.token = function(src, top, bq) {
     if (cap = this.rules.text.exec(src)) {
       // Top-level should never reach here.
       src = src.substring(cap[0].length);
-      this.tokens.push({
+      push({
         type: 'text',
         text: cap[0]
       });
+      ln += lines(cap[0]);
       continue;
     }
 
@@ -875,7 +912,7 @@ Renderer.prototype.link = function(href, title, text) {
     } catch (e) {
       return '';
     }
-    if (prot.indexOf('javascript:') === 0 || prot.indexOf('vbscript:') === 0 || prot.indexOf('data:') === 0) {
+    if (prot.indexOf('javascript:') === 0 || prot.indexOf('vbscript:') === 0) {
       return '';
     }
   }
@@ -1253,7 +1290,8 @@ marked.defaults = {
   smartypants: false,
   headerPrefix: '',
   renderer: new Renderer,
-  xhtml: false
+  xhtml: false,
+  lineNumber: false
 };
 
 /**


### PR DESCRIPTION
Hi, I add line number output support to the lexer. That's useful when I want to tell the document author which about warning and suggestions on line level.