### PR TITLE
Spell occurred correctly

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1220,7 +1220,7 @@ function marked(src, opt, callback) {
   } catch (e) {
     e.message += '\nPlease report this to https://github.com/chjj/marked.';
     if ((opt || marked.defaults).silent) {
-      return '<p>An error occured:</p><pre>'
+      return '<p>An error occurred:</p><pre>'
         + escape(e.message + '', true)
         + '</pre>';
     }


### PR DESCRIPTION
Trivial, I know... I was looking for misspellings of occurred in our project and found one in one of the dependencies, so thought I'd send you a pull request.

Enjoy!
