### PR TITLE
trim code after regexp

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -457,7 +457,7 @@ var inline = {
   nolink: /^!?\[((?:\[[^\]]*\]|[^\[\]])*)\]/,
   strong: /^__([\s\S]+?)__(?!_)|^\*\*([\s\S]+?)\*\*(?!\*)/,
   em: /^\b_((?:[^_]|__)+?)_\b|^\*((?:\*\*|[\s\S])+?)\*(?!\*)/,
-  code: /^(`+)\s*([\s\S]*?[^`])\s*\1(?!`)/,
+  code: /^(`+)([\s\S]*?[^`])\1(?!`)/,
   br: /^ {2,}\n(?!\s*$)/,
   del: noop,
   text: /^[\s\S]+?(?=[\\<!\[_*`]| {2,}\n|$)/
@@ -661,7 +661,7 @@ InlineLexer.prototype.output = function(src) {
     // code
     if (cap = this.rules.code.exec(src)) {
       src = src.substring(cap[0].length);
-      out += this.renderer.codespan(escape(cap[2], true));
+      out += this.renderer.codespan(escape(cap[2].trim(), true));
       continue;
     }
 


### PR DESCRIPTION
Trimming the code after the regexp (instead of inside the regexp) seems to fix the regexp DOS described in #937 

fixes #937 

here is code to test it:

```javascript
function genstr(len, chr) {
  var result = '';
  for (i=0; i<=len; i++) {
    result = result + chr;
  }
  return result;
}

var regex,start,output,end;

var input =  '`x' + genstr(50000, ' ') + 'x`';

regex = /^(`+)\s*([\s\S]*?[^`])\s*\1(?!`)/;
start = process.hrtime();
output = '<code>'+regex.exec(input)[2]+'</code>';
end = process.hrtime(start);

console.info(' DOS execution time (hr): %ds %dms', end[0], end[1] / 1000000);

regex = /^(`+)([\s\S]*?[^`])\1(?!`)/;
start = process.hrtime();
output = '<code>'+regex.exec(input)[2].trim()+'</code>';
end = process.hrtime(start);

console.info('Trim execution time (hr): %ds %dms', end[0], end[1] / 1000000);
```