### PR TITLE
Support older regex engines

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1137,9 +1137,9 @@ function resolveUrl(base, href) {
   base = baseUrls[' ' + base];
 
   if (href.slice(0, 2) === '//') {
-    return base.replace(/:[^]*/, ':') + href;
+    return base.replace(/:[\s\S]*/, ':') + href;
   } else if (href.charAt(0) === '/') {
-    return base.replace(/(:\/*[^/]*)[^]*/, '$1') + href;
+    return base.replace(/(:\/*[^/]*)[\s\S]*/, '$1') + href;
   } else {
     return base + href;
   }


### PR DESCRIPTION
Recent changes broke IE8 support. This makes things compatible with old regex engines (in IE8, old Safari and old Opera).
More information: https://stackoverflow.com/questions/10843428/what-is-meaning-of-in-javascript-regexps/10843677#10843677