### PR TITLE
Added support to adding simple block rules

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -112,6 +112,11 @@ function Lexer(options) {
 }
 
 /**
+ * Array of RegExp.
+ */
+Lexer.simpleRules = [];
+
+/**
  * Expose Block Rules
  */
 
@@ -156,6 +161,7 @@ Lexer.prototype.token = function(src, top, bq) {
     , i
     , l;
 
+  mainLoop:
   while (src) {
     // newline
     if (cap = this.rules.newline.exec(src)) {
@@ -406,6 +412,18 @@ Lexer.prototype.token = function(src, top, bq) {
       this.tokens.push(item);
 
       continue;
+    }
+
+    // simple rules
+    if (Lexer.simpleRules.length) {
+      var simpleRules = Lexer.simpleRules;
+      for (var i = 0; i < simpleRules.length; i++) {
+        if (cap = simpleRules[i].exec(src)) {
+          src = src.substring(cap[0].length);
+          this.tokens.push({ type: simpleRules.length, cap: cap });
+          continue mainLoop;
+        }
+      }
     }
 
     // top-level paragraph
@@ -927,6 +945,18 @@ Parser.parse = function(src, options, renderer) {
   return parser.parse(src);
 };
 
+
+/**
+ * Array of simple renderer callbacks, like this:
+ * 
+ * ```js
+ * function (cap) {
+ *   return cap[1];
+ * }
+ * ```
+ */
+Parser.prototype.simpleRenderers = [];
+
 /**
  * Parse Loop
  */
@@ -1082,6 +1112,14 @@ Parser.prototype.tok = function() {
     case 'text': {
       return this.renderer.paragraph(this.parseText());
     }
+    default: {
+      if (this.simpleRenderers.length)
+        for (var i = 0; i < this.simpleRenderers.length; i++) {
+          if (this.token.type == i + 1) {
+            return this.simpleRenderers[i].call(this.renderer, this.token.cap);
+          }
+        }
+    }
   }
 };
 
@@ -1204,7 +1242,7 @@ function marked(src, opt, callback) {
       var out;
 
       try {
-        out = Parser.parse(tokens, opt);
+        out = marked.parser(tokens, opt);
       } catch (e) {
         err = e;
       }
@@ -1245,7 +1283,7 @@ function marked(src, opt, callback) {
   }
   try {
     if (opt) opt = merge({}, marked.defaults, opt);
-    return Parser.parse(Lexer.lex(src, opt), opt);
+    return marked.parser(Lexer.lex(src, opt), opt);
   } catch (e) {
     e.message += '\nPlease report this to https://github.com/chjj/marked.';
     if ((opt || marked.defaults).silent) {
@@ -1256,6 +1294,29 @@ function marked(src, opt, callback) {
     throw e;
   }
 }
+
+/**
+ * Staticaly saved `simpleRenderers`. They are used to inject in instance of Parser.
+ */
+marked.simpleRenderers = [];
+
+marked.parser = function (src, options, renderer) {
+  if (marked.simpleRenderers.length) {
+    var parser = new Parser(options);
+    parser.simpleRenderers = marked.simpleRenderers;
+    return parser.parse(src, options, renderer);
+  }
+  else {
+    return Parser.parse(src, options, renderer);
+  }
+};
+
+marked.setBlockRule = function(regexp, renderer) {
+  Lexer.simpleRules.push(regexp);
+  this.simpleRenderers.push(renderer);
+
+  return marked;
+};
 
 /**
  * Options
@@ -1291,7 +1352,7 @@ marked.defaults = {
  */
 
 marked.Parser = Parser;
-marked.parser = Parser.parse;
+marked.escape = escape;
 
 marked.Renderer = Renderer;
 

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -420,7 +420,7 @@ Lexer.prototype.token = function(src, top, bq) {
       for (var i = 0; i < simpleRules.length; i++) {
         if (cap = simpleRules[i].exec(src)) {
           src = src.substring(cap[0].length);
-          this.tokens.push({ type: simpleRules.length, cap: cap });
+          this.tokens.push({ type: 'simpleRule' + (i + 1), cap: cap });
           continue mainLoop;
         }
       }
@@ -1115,7 +1115,7 @@ Parser.prototype.tok = function() {
     default: {
       if (this.simpleRenderers.length)
         for (var i = 0; i < this.simpleRenderers.length; i++) {
-          if (this.token.type == i + 1) {
+          if (this.token.type == 'simpleRule' + (i + 1)) {
             return this.simpleRenderers[i].call(this.renderer, this.token.cap);
           }
         }
@@ -1312,6 +1312,7 @@ marked.parser = function (src, options, renderer) {
 };
 
 marked.setBlockRule = function(regexp, renderer) {
+  renderer = renderer || function(){};
   Lexer.simpleRules.push(regexp);
   this.simpleRenderers.push(renderer);
 


### PR DESCRIPTION
```js
const marked = require('marked');
const blockStr = `
# Example usage with embed block code

@@@ gist
a9dfd77500990871fc58b97fdb57d91f.js
@@@

@@@ youtube
JgwnkM5WwWE
@@@
`;

marked.setBlockRule(/^@@@ *(\w+)\n([\s\S]+?)\n@@@/, function (execArr) {
  const channel = execArr[1];
  switch (channel) {
    case 'youtube': {
        const id = marked.escape(execArr[2]);
        return `<iframe width="420" height="315" src="https://www.youtube.com/embed/${id}"></iframe>\n`;
     }
    case 'gist': {
        const id = marked.escape(execArr[2]);
        return `<script src="https://gist.github.com/${id}"></script>\n`;
     }
  }
});
const html = marked.parse(blockStr);
console.log(html);
```

Output:

```html
<h1 id="example-usage-with-embed-block-code">Example usage with embed block code</h1>
<script src="https://gist.github.com/a9dfd77500990871fc58b97fdb57d91f.js"></script>
<iframe width="420" height="315" src="https://www.youtube.com/embed/JgwnkM5WwWE"></iframe>
```
  