### PR TITLE
Print help without `man`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,4 +9,7 @@ clean:
 bench:
 	@node test --bench
 
+man/marked.1.txt:
+	groff -man -Tascii man/marked.1 | col -b > man/marked.1.txt
+
 .PHONY: clean all

--- a/bin/marked
+++ b/bin/marked
@@ -23,9 +23,13 @@ function help() {
     customFds: [0, 1, 2]
   };
 
-  spawn('man',
-    [__dirname + '/../man/marked.1'],
-    options);
+  spawn('man', [__dirname + '/../man/marked.1'], options)
+    .on('error', function(err) {
+      fs.readFile(__dirname + '/../man/marked.1.txt', 'utf8', function(err, data) {
+        if (err) throw err;
+        console.log(data);
+      });
+    });
 }
 
 /**

--- a/man/marked.1.txt
+++ b/man/marked.1.txt
@@ -1,0 +1,96 @@
+marked(1)			   marked.js			     marked(1)
+
+
+
+NAME
+       marked - a javascript markdown parser
+
+
+SYNOPSIS
+       marked  [-o  <output>]  [-i  <input>]  [--help] [--tokens] [--pedantic]
+       [--gfm] [--breaks] [--tables] [--sanitize] [--smart-lists] [--lang-pre‐
+       fix <prefix>] [--no-etc...] [--silent] [filename]
+
+
+DESCRIPTION
+       marked  is a full-featured javascript markdown parser, built for speed.
+       It also includes multiple GFM features.
+
+
+EXAMPLES
+       cat in.md | marked > out.html
+
+       echo "hello *world*" | marked
+
+       marked -o out.html in.md --gfm
+
+       marked --output="hello world.html" -i in.md --no-breaks
+
+
+OPTIONS
+       -o, --output [output]
+	      Specify file output. If none is specified, write to stdout.
+
+       -i, --input [input]
+	      Specify file input, otherwise use last argument as  input  file.
+	      If no input file is specified, read from stdin.
+
+       -t, --tokens
+	      Output a token stream instead of html.
+
+       --pedantic
+	      Conform  to  obscure  parts  of markdown.pl as much as possible.
+	      Don't fix original markdown bugs.
+
+       --gfm  Enable github flavored markdown.
+
+       --breaks
+	      Enable GFM line breaks. Only works with the gfm option.
+
+       --tables
+	      Enable GFM tables. Only works with the gfm option.
+
+       --sanitize
+	      Sanitize output. Ignore any HTML input.
+
+       --smart-lists
+	      Use smarter list behavior than the original markdown.
+
+       --lang-prefix [prefix]
+	      Set the prefix for code block classes.
+
+       --mangle
+	      Mangle email addresses.
+
+       --no-sanitize, -no-etc...
+	      The inverse of any of the marked options above.
+
+       --silent
+	      Silence error output.
+
+       -h, --help
+	      Display help information.
+
+
+CONFIGURATION
+       For configuring and running programmatically.
+
+       Example
+
+	   require('marked')('*foo*', { gfm: true });
+
+
+BUGS
+       Please report any bugs to https://github.com/chjj/marked.
+
+
+LICENSE
+       Copyright (c) 2011-2014, Christopher Jeffrey (MIT License).
+
+
+SEE ALSO
+       markdown(1), node.js(1)
+
+
+
+v0.3.1				  2014-01-31			     marked(1)


### PR DESCRIPTION
This fixes #992, at least temporarily.

See also #994

I've parsed the manpage in order to generate a textual version stripped of any escape characters. Whenever `--help` is called and `man` cannot be run, it simply prints this textual version on the screen, as suggested by @UziTech [here](https://github.com/chjj/marked/pull/994#issuecomment-355573220).