### PR TITLE
Preserve trailing newlines in code fences

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -76,7 +76,7 @@ block.normal = merge({}, block);
  */
 
 block.gfm = merge({}, block.normal, {
-  fences: /^ *(`{3,}|~{3,})[ \.]*(\S+)? *\n([\s\S]*?)\s*\1 *(?:\n+|$)/,
+  fences: /^ *(`{3,}|~{3,})[ \.]*(\S+)? *\n([\s\S]*?)\n? *\1 *(?:\n+|$)/,
   paragraph: /^/,
   heading: /^ *(#{1,6}) +([^\n]+?) *#* *(?:\n+|$)/
 });

--- a/test/new/gfm_code.html
+++ b/test/new/gfm_code.html
@@ -8,3 +8,9 @@ console.log(a + &#39; world&#39;);</code></pre>
 <p>How about a code block with only an empty line?</p>
 <pre><code class="lang-js">
 </code></pre>
+
+<p>With some trailing empty lines:</p>
+<pre><code>ciao
+
+
+</code></pre>

--- a/test/new/gfm_code.md
+++ b/test/new/gfm_code.md
@@ -25,3 +25,11 @@ How about a code block with only an empty line?
 ```js
 
 ```
+
+With some trailing empty lines:
+
+```
+ciao
+
+
+```


### PR DESCRIPTION
This fixes #645 and fixes #931.

Preserve trailing newlines in code fence per [commonmark spec](http://spec.commonmark.org/0.28/#example-98).

~~~markdown
```js
ciao();


```
~~~
becomes
~~~html
<pre><code class="lang-js">ciao();


</code></pre>
~~~

This includes tests, which are not useful since whitespace is not checked for in our test routine. (Might need to fix this too)