### PR TITLE
fix backticks in inline code (replaces #503, fixes #312)

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -458,7 +458,7 @@ var inline = {
   nolink: /^!?\[((?:\[[^\]]*\]|[^\[\]])*)\]/,
   strong: /^__([\s\S]+?)__(?!_)|^\*\*([\s\S]+?)\*\*(?!\*)/,
   em: /^\b_((?:[^_]|__)+?)_\b|^\*((?:\*\*|[\s\S])+?)\*(?!\*)/,
-  code: /^(`+)([\s\S]*?[^`])\1(?!`)/,
+  code: /^(`+)(\s*)([\s\S]*?[^`]?)\2\1(?!`)/,
   br: /^ {2,}\n(?!\s*$)/,
   del: noop,
   text: /^[\s\S]+?(?=[\\<!\[_*`]| {2,}\n|$)/
@@ -664,7 +664,7 @@ InlineLexer.prototype.output = function(src) {
     // code
     if (cap = this.rules.code.exec(src)) {
       src = src.substring(cap[0].length);
-      out += this.renderer.codespan(escape(cap[2].trim(), true));
+      out += this.renderer.codespan(escape(cap[3].trim(), true));
       continue;
     }
 

--- a/test/new/nested_code.html
+++ b/test/new/nested_code.html
@@ -1,1 +1,9 @@
 <p><code>hi ther `` ok ```</code></p>
+
+<p><code>`</code></p>
+
+<p><code>There is a literal backtick (`) here.</code></p>
+
+<p>A backtick-delimited string in a code span: <code>`foo`</code></p>
+
+<p>Please don&#39;t use any <code>&lt;blink&gt;</code> tags.</p>

--- a/test/new/nested_code.md
+++ b/test/new/nested_code.md
@@ -1,1 +1,9 @@
 ````` hi ther `` ok ``` `````
+
+`` ` ``
+
+``There is a literal backtick (`) here.``
+
+A backtick-delimited string in a code span: `` `foo` ``
+
+Please don't use any `<blink>` tags.


### PR DESCRIPTION
Fixes #312:

~~~html
$ marked
`` ` ``
^D
<p><code>` </code></p>
~~~

Tests are about checking for whitespace, which is ignored by our test system for now.