### PR TITLE
[commonmark] Make blockquotes commonmark compliant

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -19,12 +19,12 @@ var block = {
   heading: /^ *(#{1,6}) *([^\n]+?) *#* *(?:\n+|$)/,
   nptable: noop,
   lheading: /^([^\n]+)\n *(=|-){2,} *(?:\n+|$)/,
-  blockquote: /^( *>[^\n]+(\n(?!def)[^\n]+)*\n*)+/,
+  blockquote: /^( {0,3}> ?(paragraph|[^\n]*)(?:\n|$))+/,
   list: /^( *)(bull) [\s\S]+?(?:hr|def|\n{2,}(?! )(?!\1bull )\n*|\s*$)/,
   html: /^ *(?:comment *(?:\n|\s*$)|closed *(?:\n{2,}|\s*$)|closing *(?:\n{2,}|\s*$))/,
   def: /^ {0,3}\[(label)\]: *\n? *<?([^\s>]+)>?(?:(?: +\n? *| *\n *)(title))? *(?:\n+|$)/,
   table: noop,
-  paragraph: /^((?:[^\n]+\n?(?!hr|heading|lheading|blockquote|tag))+)\n*/,
+  paragraph: /^([^\n]+(?:\n?(?!hr|heading|lheading| {0,3}>|tag)[^\n]+)+)/,
   text: /^[^\n]+/
 };
 
@@ -47,10 +47,6 @@ block.list = replace(block.list)
   ('def', '\\n+(?=' + block.def.source + ')')
   ();
 
-block.blockquote = replace(block.blockquote)
-  ('def', block.def)
-  ();
-
 block._tag = '(?!(?:'
   + 'a|em|strong|small|s|cite|q|dfn|abbr|data|time|code'
   + '|var|samp|kbd|sub|sup|i|b|u|mark|ruby|rt|rp|bdi|bdo'
@@ -67,8 +63,11 @@ block.paragraph = replace(block.paragraph)
   ('hr', block.hr)
   ('heading', block.heading)
   ('lheading', block.lheading)
-  ('blockquote', block.blockquote)
   ('tag', '<' + block._tag)
+  ();
+
+block.blockquote = replace(block.blockquote)
+  ('paragraph', block.paragraph)
   ();
 
 /**

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -18,12 +18,12 @@ var block = {
   hr: /^( *[-*_]){3,} *(?:\n+|$)/,
   heading: /^ *(#{1,6}) *([^\n]+?) *#* *(?:\n+|$)/,
   nptable: noop,
-  lheading: /^([^\n]+)\n *(=|-){2,} *(?:\n+|$)/,
   blockquote: /^( {0,3}> ?(paragraph|[^\n]*)(?:\n|$))+/,
   list: /^( *)(bull) [\s\S]+?(?:hr|def|\n{2,}(?! )(?!\1bull )\n*|\s*$)/,
   html: /^ *(?:comment *(?:\n|\s*$)|closed *(?:\n{2,}|\s*$)|closing *(?:\n{2,}|\s*$))/,
   def: /^ {0,3}\[(label)\]: *\n? *<?([^\s>]+)>?(?:(?: +\n? *| *\n *)(title))? *(?:\n+|$)/,
   table: noop,
+  lheading: /^([^\n]+)\n *(=|-){2,} *(?:\n+|$)/,
   paragraph: /^([^\n]+(?:\n?(?!hr|heading|lheading| {0,3}>|tag)[^\n]+)+)/,
   text: /^[^\n]+/
 };
@@ -244,17 +244,6 @@ Lexer.prototype.token = function(src, top) {
       continue;
     }
 
-    // lheading
-    if (cap = this.rules.lheading.exec(src)) {
-      src = src.substring(cap[0].length);
-      this.tokens.push({
-        type: 'heading',
-        depth: cap[2] === '=' ? 1 : 2,
-        text: cap[1]
-      });
-      continue;
-    }
-
     // hr
     if (cap = this.rules.hr.exec(src)) {
       src = src.substring(cap[0].length);
@@ -419,6 +408,17 @@ Lexer.prototype.token = function(src, top) {
 
       this.tokens.push(item);
 
+      continue;
+    }
+
+    // lheading
+    if (cap = this.rules.lheading.exec(src)) {
+      src = src.substring(cap[0].length);
+      this.tokens.push({
+        type: 'heading',
+        depth: cap[2] === '=' ? 1 : 2,
+        text: cap[1]
+      });
       continue;
     }
 

--- a/test/new/cm_blockquotes.html
+++ b/test/new/cm_blockquotes.html
@@ -1,0 +1,239 @@
+<h3 id="example-191">Example 191</h3>
+
+<blockquote>
+<h1 id="foo">Foo</h1>
+<p>bar
+baz</p>
+</blockquote>
+
+<h3 id="example-192">Example 192</h3>
+
+<p>The spaces after the <code>&gt;</code> characters can be omitted:</p>
+
+<blockquote>
+<h1 id="foo">Foo</h1>
+<p>bar
+baz</p>
+</blockquote>
+
+<h3 id="example-193">Example 193</h3>
+
+<p>The <code>&gt;</code> characters can be indented 1-3 spaces:</p>
+
+<blockquote>
+<h1 id="foo">Foo</h1>
+<p>bar
+baz</p>
+</blockquote>
+
+<h3 id="example-194">Example 194</h3>
+
+<p>Four spaces gives us a code block:</p>
+
+<pre><code>&gt; # Foo
+&gt; bar
+&gt; baz
+</code></pre>
+
+<h3 id="example-195">Example 195</h3>
+
+<p>The Laziness clause allows us to omit the <code>&gt;</code> before paragraph continuation text:</p>
+
+<blockquote>
+<h1 id="foo">Foo</h1>
+<p>bar
+baz</p>
+</blockquote>
+
+<h3 id="example-196">Example 196</h3>
+
+<p>A block quote can contain some lazy and some non-lazy continuation lines:</p>
+
+<blockquote>
+<p>bar
+baz
+foo</p>
+</blockquote>
+
+<h3 id="example-197">Example 197</h3>
+
+<p>Laziness only applies to lines that would have been continuations of paragraphs had they been prepended with block quote markers. For example, the <code>&gt;</code> cannot be omitted in the second line of</p>
+
+<blockquote>
+<p>foo</p>
+</blockquote>
+<hr>
+
+<p>without changing the meaning.</p>
+
+<h3 id="example-198">Example 198</h3>
+
+<pre><code>Similarly, if we omit the `&gt;` in the second line then the block quote ends after the first line:
+
+&gt; - foo
+- bar</code></pre>
+
+<h3 id="example-199">Example 199</h3>
+
+<p>For the same reason, we can’t omit the <code>&gt;</code> in front of subsequent lines of an indented or fenced code block:</p>
+
+<blockquote>
+<pre><code>foo
+</code></pre>
+</blockquote>
+<pre><code>bar
+</code></pre>
+
+<h3 id="example-200">Example 200</h3>
+
+<pre><code>&gt; ```
+foo
+```
+
+&lt;blockquote&gt;
+&lt;pre&gt;&lt;code&gt;&lt;/code&gt;&lt;/pre&gt;
+&lt;/blockquote&gt;
+&lt;p&gt;foo&lt;/p&gt;
+&lt;pre&gt;&lt;code&gt;&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+
+<h3 id="example-201">Example 201</h3>
+<pre><code>&gt; foo
+    - bar
+
+&lt;blockquote&gt;
+&lt;p&gt;foo
+- bar&lt;/p&gt;
+&lt;/blockquote&gt;
+</code></pre>
+
+<h3 id="example-202">Example 202</h3>
+
+<p>A block quote can be empty:</p>
+
+<blockquote>
+</blockquote>
+
+<h3 id="example-203">Example 203</h3>
+
+<blockquote>
+</blockquote>
+
+<h3 id="example-204">Example 204</h3>
+
+<p>A block quote can have initial or final blank lines:</p>
+
+<blockquote>
+<p>foo</p>
+</blockquote>
+
+
+<h3 id="example-205">Example 205</h3>
+
+<p>A blank line always separates block quotes:</p>
+
+<blockquote>
+<p>foo</p>
+</blockquote>
+<blockquote>
+<p>bar</p>
+</blockquote>
+
+<h3 id="example-206">Example 206</h3>
+
+<p>Consecutiveness means that if we put these block quotes together, we get a single block quote:</p>
+
+<blockquote>
+<p>foo
+bar</p>
+</blockquote>
+
+<h3 id="example-207">Example 207</h3>
+
+<p>To get a block quote with two paragraphs, use:</p>
+
+<blockquote>
+<p>foo</p>
+<p>bar</p>
+</blockquote>
+
+<h3 id="example-208">Example 208</h3>
+
+<p>Block quotes can interrupt paragraphs:</p>
+
+<p>foo</p>
+<blockquote>
+<p>bar</p>
+</blockquote>
+
+<h3 id="example-209">Example 209</h3>
+
+<p>In general, blank lines are not needed before or after block quotes:</p>
+
+<blockquote>
+<p>aaa</p>
+</blockquote>
+<hr>
+<blockquote>
+<p>bbb</p>
+</blockquote>
+
+<h3 id="example-210">Example 210</h3>
+
+<p>However, because of laziness, a blank line is needed between a block quote and a following paragraph:</p>
+
+<blockquote>
+<p>bar
+baz</p>
+</blockquote>
+
+<h3 id="example-211">Example 211</h3>
+
+<blockquote>
+<p>bar</p>
+</blockquote>
+<p>baz</p>
+
+<h3 id="example-212">Example 212</h3>
+
+<blockquote>
+<p>bar</p>
+</blockquote>
+<p>baz</p>
+
+<h3 id="example-213">Example 213</h3>
+
+<p>It is a consequence of the Laziness rule that any number of initial <code>&gt;</code>s may be omitted on a continuation line of a nested block quote:</p>
+
+<blockquote>
+<blockquote>
+<blockquote>
+<p>foo
+bar</p>
+</blockquote>
+</blockquote>
+</blockquote>
+
+<h3 id="example-214">Example 214</h3>
+
+<blockquote>
+<blockquote>
+<blockquote>
+<p>foo
+bar
+baz</p>
+</blockquote>
+</blockquote>
+</blockquote>
+
+<h3 id="example-215">Example 215</h3>
+
+<p>When including an indented code block in a block quote, remember that the block quote marker includes both the <code>&gt;</code> and a following space. So five spaces are needed after the <code>&gt;</code>:</p>
+
+<blockquote>
+<pre><code>code
+</code></pre>
+</blockquote>
+<blockquote>
+<p>not code</p>
+</blockquote>

--- a/test/new/cm_blockquotes.md
+++ b/test/new/cm_blockquotes.md
@@ -1,0 +1,189 @@
+### Example 191
+
+> # Foo
+> bar
+> baz
+
+### Example 192
+
+The spaces after the `>` characters can be omitted:
+
+># Foo
+>bar
+> baz
+
+### Example 193
+
+The `>` characters can be indented 1-3 spaces:
+
+   > # Foo
+   > bar
+ > baz
+
+### Example 194
+
+Four spaces gives us a code block:
+
+    > # Foo
+    > bar
+    > baz
+
+### Example 195
+
+The Laziness clause allows us to omit the `>` before paragraph continuation text:
+
+> # Foo
+> bar
+baz
+
+### Example 196
+
+A block quote can contain some lazy and some non-lazy continuation lines:
+
+> bar
+baz
+> foo
+
+### Example 197
+
+Laziness only applies to lines that would have been continuations of paragraphs had they been prepended with block quote markers. For example, the `>` cannot be omitted in the second line of
+
+> foo
+---
+
+without changing the meaning.
+
+### Example 198
+
+    Similarly, if we omit the `>` in the second line then the block quote ends after the first line:
+
+    > - foo
+    - bar
+
+### Example 199
+
+For the same reason, we can’t omit the `>` in front of subsequent lines of an indented or fenced code block:
+
+>     foo
+
+    bar
+
+### Example 200
+
+    > ```
+    foo
+    ```
+
+    <blockquote>
+    <pre><code></code></pre>
+    </blockquote>
+    <p>foo</p>
+    <pre><code></code></pre>
+
+### Example 201
+
+    > foo
+        - bar
+
+    <blockquote>
+    <p>foo
+    - bar</p>
+    </blockquote>
+
+### Example 202
+
+A block quote can be empty:
+
+>
+
+### Example 203
+
+>
+>  
+> 
+
+### Example 204
+
+A block quote can have initial or final blank lines:
+
+>
+> foo
+>  
+
+### Example 205
+
+A blank line always separates block quotes:
+
+> foo
+
+> bar
+
+### Example 206
+
+Consecutiveness means that if we put these block quotes together, we get a single block quote:
+
+> foo
+> bar
+
+### Example 207
+
+To get a block quote with two paragraphs, use:
+
+> foo
+>
+> bar
+
+### Example 208
+
+Block quotes can interrupt paragraphs:
+
+foo
+> bar
+
+### Example 209
+
+In general, blank lines are not needed before or after block quotes:
+
+> aaa
+***
+> bbb
+
+### Example 210
+
+However, because of laziness, a blank line is needed between a block quote and a following paragraph:
+
+> bar
+baz
+
+### Example 211
+
+> bar
+
+baz
+
+### Example 212
+
+> bar
+>
+baz
+
+### Example 213
+
+It is a consequence of the Laziness rule that any number of initial `>`s may be omitted on a continuation line of a nested block quote:
+
+> > > foo
+bar
+
+### Example 214
+
+>>> foo
+> bar
+>>baz
+
+### Example 215
+
+When including an indented code block in a block quote, remember that the block quote marker includes both the `>` and a following space. So five spaces are needed after the `>`:
+
+>     code
+
+>    not code

--- a/test/new/def_blocks.html
+++ b/test/new/def_blocks.html
@@ -6,7 +6,8 @@
 <hr>
 
 <blockquote>
-  <p>hello</p>
+  <p>hello
+[2]: hello</p>
 </blockquote>
 
 
@@ -24,5 +25,6 @@
 <blockquote>
   <p>foo
 bar
+[5]: foo
 bar</p>
 </blockquote>

--- a/test/new/def_blocks.md
+++ b/test/new/def_blocks.md
@@ -17,5 +17,5 @@
 
 > foo
 > bar
-[1]: foo
+[5]: foo
 > bar

--- a/test/new/toplevel_paragraphs.html
+++ b/test/new/toplevel_paragraphs.html
@@ -1,30 +1,30 @@
 <p>hello world
-    how are you
-    how are you</p>
+    text after spaces
+    text after spaces</p>
 
-<p>hello world</p>
-<pre><code>how are you</code></pre>
+<p>paragraph before code</p>
+<pre><code>text inside block code</code></pre>
 
-<p>hello world</p>
+<p>paragraph before hr</p>
 <hr>
 
-<p>hello world</p>
+<p>paragraph before head with hash</p>
 <h1 id="how-are-you">how are you</h1>
 
-<p>hello world</p>
+<p>paragraph before head with equals</p>
 <h1 id="how-are-you">how are you</h1>
 
-<p>hello world</p>
-<blockquote><p>how are you</p></blockquote>
+<p>paragraph before blockquote</p>
+<blockquote><p>text for blockquote</p></blockquote>
 
-<p>hello world</p>
-<ul><li>how are you</li></ul>
+<p>paragraph before list</p>
+<ul><li>text inside list</li></ul>
 
-<p>hello world</p>
-<div>how are you</div>
+<p>paragraph before div</p>
+<div>text inside div</div>
 
-<p>hello world
-<span>how are you</span></p>
+<p>paragraph with span
+<span>text inside span</span></p>
 
 <p>hello <a href="/are/you">world</a>
 </p>

--- a/test/new/toplevel_paragraphs.md
+++ b/test/new/toplevel_paragraphs.md
@@ -2,35 +2,35 @@
 gfm: true
 ---
 hello world
-    how are you
-    how are you
+    text after spaces
+    text after spaces
 
-hello world
+paragraph before code
 ```
-how are you
+text inside block code
 ```
 
-hello world
+paragraph before hr
 * * *
 
-hello world
+paragraph before head with hash
 # how are you
 
-hello world
+paragraph before head with equals
 how are you
 ===========
 
-hello world
-> how are you
+paragraph before blockquote
+> text for blockquote
 
-hello world
-* how are you
+paragraph before list
+* text inside list
 
-hello world
-<div>how are you</div>
+paragraph before div
+<div>text inside div</div>
 
-hello world
-<span>how are you</span>
+paragraph with span
+<span>text inside span</span>
 
 hello [world][how]
 


### PR DESCRIPTION
I've made blockquotes (almost 100%) compliant with the commonmark [spec], and added the related test cases, from the spec itself. They all pass, but I was not able to pass example 198 and 200 because they are related to list and code fences rules. This will need to be fixed in the future if anyone's up to it.

Many thanks to @KostyaTretyak who helped in solving related issues before

[spec]: http://spec.commonmark.org/0.28/#block-quotes