### PR TITLE
Make legacy test literal_quotes_in_titles pass

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -29,7 +29,7 @@ var block = {
 };
 
 block._label = /(?:\\[\[\]]|[^\[\]])+/;
-block._title = /(?:"(?:\\"|[^"])*"|'\n?(?:[^'\n]+\n?)*'|\([^()]*\))/;
+block._title = /(?:"(?:\\"|[^"]|"[^"\n]*")*"|'\n?(?:[^'\n]+\n?)*'|\([^()]*\))/;
 block.def = replace(block.def)
   ('label', block._label)
   ('title', block._title)


### PR DESCRIPTION
As I explained [here](https://github.com/chjj/marked/pull/1018#issuecomment-359207001):

With the new commonmark compliant rule for link definitions, literal (matched) doubles quotes in titles are not supported anymore, so this legacy test from markdown.pl failed. I re-added support for this (even if it is against the cm spec).
Backslash-escaped (non-matching) quotes are still supported.

I did not consider it worth to create a separate `pedantic` rule for this.
(pedantic means it is going to replicate markdown.pl behavior exactly)